### PR TITLE
Using cpShapeSet* if shape->body is NULL

### DIFF
--- a/include/chipmunk/cpShape.h
+++ b/include/chipmunk/cpShape.h
@@ -117,7 +117,7 @@ static inline type cpShapeGet##name(const cpShape *shape){return shape->member;}
 
 #define CP_DefineShapeStructSetter(type, member, name, activates) \
 static inline void cpShapeSet##name(cpShape *shape, type value){ \
-	if(activates) cpBodyActivate(shape->body); \
+	if(activates && shape->body) cpBodyActivate(shape->body); \
 	shape->member = value; \
 }
 


### PR DESCRIPTION
Hi

This commit fixes a crash caused by calling `cpBodyActivate` on NULL — from the macro `cpShapeSet*`
This can happen if `shape->body` is set after the creation of the shape (but still before adding it to a Space).
