### PR TITLE
$ARCHS_STANDARD_32_BIT only builds for armv7 architecture

### DIFF
--- a/macosx/Chipmunk6.xcodeproj/project.pbxproj
+++ b/macosx/Chipmunk6.xcodeproj/project.pbxproj
@@ -675,7 +675,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				ARCHS = (
+					armv6,
+					armv7,
+				);
 				COPY_PHASE_STRIP = NO;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_THUMB_SUPPORT = NO;
@@ -691,7 +694,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				ARCHS = (
+					armv6,
+					armv7,
+				);
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				GCC_AUTO_VECTORIZATION = YES;


### PR DESCRIPTION
As of Xcode 4.2 we need to specify armv6 (in addition to armv7) if we want to support older iDevices such as the iPhone 3G.
