### PR TITLE
Proper macro statement for Mac

### DIFF
--- a/include/chipmunk/chipmunk_types.h
+++ b/include/chipmunk/chipmunk_types.h
@@ -203,7 +203,7 @@ typedef uintptr_t cpHashValue;
 
 // CGPoints are structurally the same, and allow
 // easy interoperability with other Cocoa libraries
-#ifdef CP_USE_CGPOINTS
+#if CP_USE_CGPOINTS
 	typedef CGPoint cpVect;
 #else
 /// Chipmunk's 2D vector type.


### PR DESCRIPTION
Setting both -DCP_USE_CGPOINTS=0 and -DCP_USE_DOUBLES=0 leads to compilation error on Mac. 
