### PR TITLE
cpPolyShapeInit takes verts as const pointer

### DIFF
--- a/include/chipmunk/cpPolyShape.h
+++ b/include/chipmunk/cpPolyShape.h
@@ -41,7 +41,7 @@ typedef struct cpPolyShape {
 cpPolyShape* cpPolyShapeAlloc(void);
 /// Initialize a polygon shape.
 /// A convex hull will be created from the vertexes.
-cpPolyShape* cpPolyShapeInit(cpPolyShape *poly, cpBody *body, int numVerts, cpVect *verts, cpVect offset);
+cpPolyShape* cpPolyShapeInit(cpPolyShape *poly, cpBody *body, int numVerts, const cpVect *verts, cpVect offset);
 /// Allocate and initialize a polygon shape.
 /// A convex hull will be created from the vertexes.
 cpShape* cpPolyShapeNew(cpBody *body, int numVerts, cpVect *verts, cpVect offset);

--- a/src/cpPolyShape.c
+++ b/src/cpPolyShape.c
@@ -181,7 +181,7 @@ cpPolyShapeGetVert(cpShape *shape, int idx)
 
 
 static void
-setUpVerts(cpPolyShape *poly, int numVerts, cpVect *verts, cpVect offset)
+setUpVerts(cpPolyShape *poly, int numVerts, const cpVect *verts, cpVect offset)
 {
 	// Fail if the user attempts to pass a concave poly, or a bad winding.
 	cpAssertHard(cpPolyValidate(verts, numVerts), "Polygon is concave or has a reversed winding. Consider using cpConvexHull() or CP_CONVEX_HULL().");
@@ -205,7 +205,7 @@ setUpVerts(cpPolyShape *poly, int numVerts, cpVect *verts, cpVect offset)
 }
 
 cpPolyShape *
-cpPolyShapeInit(cpPolyShape *poly, cpBody *body, int numVerts, cpVect *verts, cpVect offset)
+cpPolyShapeInit(cpPolyShape *poly, cpBody *body, int numVerts, const cpVect *verts, cpVect offset)
 {
 	setUpVerts(poly, numVerts, verts, offset);
 	cpShapeInit((cpShape *)poly, &polyClass, body);


### PR DESCRIPTION
Since `cpPolyShapeInit` doesn't modify the verts array it receives, it should take it as const.
