### PR TITLE
Fix for broken NaN check.

### DIFF
--- a/include/chipmunk/cpBody.h
+++ b/include/chipmunk/cpBody.h
@@ -230,7 +230,7 @@ static inline cpFloat cpBodyKineticEnergy(const cpBody *body)
 	// Need to do some fudging to avoid NaNs
 	cpFloat vsq = cpvdot(body->v, body->v);
 	cpFloat wsq = body->w*body->w;
-	return (vsq ? vsq*body->m : 0.0f) + (wsq ? wsq*body->i : 0.0f);
+	return (isnan(vsq) ? 0.0f : vsq*body->m) + (isnan(wsq) ? 0.0f : wsq*body->i);
 }
 
 /// Body/shape iterator callback function type. 


### PR DESCRIPTION
I was looking at code in cpBody.h, specifically cpBodyKineticEnergy, and if I'm reading it right you're trying to do a boolean check to see if vsq and wsq are NaNs. My understanding is that NaN always evaluates to boolean true making these checks broken.

Here's some additional info: http://stackoverflow.com/a/9159641

I'm submitting a fix with isnan(), which is a C99 macro. You could also use the (x != x) trick, but I've seen some say that breaks under g++ with -ffast-math.

You could probably throw in
# ifndef isnan
# define isnan(x) (x != x)
# endif

and cover more ground.
