### PR TITLE
Fix compilation in MSVC through CMake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,9 +34,11 @@ if(BUILD_DEMOS OR INSTALL_STATIC)
   set(BUILD_STATIC ON FORCE)
 endif()
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99") # always use gnu99
-set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -ffast-math") # extend release-profile with fast-math
-set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -Wall") # extend debug-profile with -Wall
+if(NOT MSVC)
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99") # always use gnu99
+  set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -ffast-math") # extend release-profile with fast-math
+  set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -Wall") # extend debug-profile with -Wall
+endif()
 
 add_subdirectory(src)
 

--- a/Demo/CMakeLists.txt
+++ b/Demo/CMakeLists.txt
@@ -9,16 +9,25 @@ set(chipmunk_demos_include_dirs
 
 set(chipmunk_demos_libraries
   chipmunk_static
-  m
   ${GLUT_LIBRARIES}
   ${OPENGL_LIBRARIES}
 )
+
+if(NOT MSVC)
+  list(APPEND chipmunk_demos_libraries m)
+endif(NOT MSVC)
 
 file(GLOB chipmunk_demos_source_files "*.c")
 
 include_directories(${chipmunk_demos_include_dirs})
 add_executable(chipmunk_demos ${chipmunk_demos_source_files})
 target_link_libraries(chipmunk_demos ${chipmunk_demos_libraries})
+
+# Tell MSVC to compile the code as C++.
+if(MSVC)
+  set_source_files_properties(${chipmunk_demos_source_files} PROPERTIES LANGUAGE CXX)
+  set_target_properties(chipmunk_demos PROPERTIES LINKER_LANGUAGE CXX)
+endif(MSVC)
 
 if(INSTALL_DEMOS)
   install(TARGETS chipmunk_demos RUNTIME DESTINATION bin)

--- a/include/chipmunk/chipmunk.h
+++ b/include/chipmunk/chipmunk.h
@@ -22,6 +22,10 @@
 #ifndef CHIPMUNK_HEADER
 #define CHIPMUNK_HEADER
 
+#ifdef _MSC_VER
+    #define _USE_MATH_DEFINES
+#endif
+
 #include <stdlib.h>
 #include <math.h>
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,6 +8,11 @@ if(BUILD_SHARED)
   add_library(chipmunk SHARED
     ${chipmunk_source_files}
   )
+  # Tell MSVC to compile the code as C++.
+  if(MSVC)
+    set_source_files_properties(${chipmunk_source_files} PROPERTIES LANGUAGE CXX)
+    set_target_properties(chipmunk PROPERTIES LINKER_LANGUAGE CXX)
+  endif(MSVC)
   # set the lib's version number
   set_target_properties(chipmunk PROPERTIES VERSION 6.1.3)
   install(TARGETS chipmunk RUNTIME DESTINATION lib LIBRARY DESTINATION lib)
@@ -17,6 +22,11 @@ if(BUILD_STATIC)
   add_library(chipmunk_static STATIC
     ${chipmunk_source_files}
   )
+  # Tell MSVC to compile the code as C++.
+  if(MSVC)
+    set_source_files_properties(${chipmunk_source_files} PROPERTIES LANGUAGE CXX)
+    set_target_properties(chipmunk_static PROPERTIES LINKER_LANGUAGE CXX)
+  endif(MSVC)
   # Sets chipmunk_static to output "libchipmunk.a" not "libchipmunk_static.a"
   set_target_properties(chipmunk_static PROPERTIES OUTPUT_NAME chipmunk)
   if(INSTALL_STATIC)


### PR DESCRIPTION
When using the CMake projects to compile, MSVC will show tons of errors. This is because it should treat the files as C++ code, not C code. (Because MSVC's C compiler is still in the stone-age.)

The whole point of CMake is to have only one "project file" for all systems. I am currently including Chipmunk in my project through CMake and it works on all platforms but MSVC. This fixes it.
