### PR TITLE
Sreich add header guards

### DIFF
--- a/include/chipmunk/chipmunk.h
+++ b/include/chipmunk/chipmunk.h
@@ -221,3 +221,4 @@ static inline cpVect operator -(const cpVect v){return cpvneg(v);}
 
 #endif
 #endif
+

--- a/include/chipmunk/chipmunk_ffi.h
+++ b/include/chipmunk/chipmunk_ffi.h
@@ -175,3 +175,4 @@ MAKE_REF(cpSpaceGetCurrentTimeStep);
 MAKE_REF(cpSpaceIsLocked);
 
 #endif
+

--- a/include/chipmunk/chipmunk_private.h
+++ b/include/chipmunk/chipmunk_private.h
@@ -19,6 +19,9 @@
  * SOFTWARE.
  */
 
+#ifndef CHIPMUNK_PRIVATE_HEADER
+#define CHIPMUNK_PRIVATE_HEADER
+
 #define CP_ALLOW_PRIVATE_ACCESS 1
 #include "chipmunk.h"
 
@@ -263,3 +266,6 @@ void cpArbiterUpdate(cpArbiter *arb, cpContact *contacts, int numContacts, struc
 void cpArbiterPreStep(cpArbiter *arb, cpFloat dt, cpFloat bias, cpFloat slop);
 void cpArbiterApplyCachedImpulse(cpArbiter *arb, cpFloat dt_coef);
 void cpArbiterApplyImpulse(cpArbiter *arb);
+
+#endif // guard
+

--- a/include/chipmunk/chipmunk_types.h
+++ b/include/chipmunk/chipmunk_types.h
@@ -1,3 +1,6 @@
+#ifndef CHIPMUNK_TYPES_HEADER
+#define CHIPMUNK_TYPES_HEADER
+
 #include <stdint.h>
 
 #ifdef __APPLE__
@@ -213,3 +216,6 @@ typedef struct cpMat2x2 {
 	// Row major [[a, b][c d]]
 	cpFloat a, b, c, d;
 } cpMat2x2;
+
+#endif //guard
+

--- a/include/chipmunk/chipmunk_unsafe.h
+++ b/include/chipmunk/chipmunk_unsafe.h
@@ -61,3 +61,4 @@ void cpPolyShapeSetVerts(cpShape *shape, int numVerts, cpVect *verts, cpVect off
 #endif
 #endif
 /// @}
+

--- a/include/chipmunk/cpArbiter.h
+++ b/include/chipmunk/cpArbiter.h
@@ -19,6 +19,9 @@
  * SOFTWARE.
  */
 
+#ifndef CHIPMUNK_ARBITER_HEADER
+#define CHIPMUNK_ARBITER_HEADER
+
 /// @defgroup cpArbiter cpArbiter
 /// The cpArbiter struct controls pairs of colliding shapes.
 /// They are also used in conjuction with collision handler callbacks
@@ -205,3 +208,6 @@ cpVect cpArbiterGetPoint(const cpArbiter *arb, int i);
 cpFloat cpArbiterGetDepth(const cpArbiter *arb, int i);
 
 /// @}
+
+#endif //guard
+

--- a/include/chipmunk/cpBB.h
+++ b/include/chipmunk/cpBB.h
@@ -19,6 +19,9 @@
  * SOFTWARE.
  */
 
+#ifndef CHIPMUNK_BB_HEADER
+#define CHIPMUNK_BB_HEADER
+
 /// @defgroup cpBBB cpBB
 /// Chipmunk's axis-aligned 2D bounding box type along with a few handy routines.
 /// @{
@@ -134,3 +137,6 @@ cpBBClampVect(const cpBB bb, const cpVect v)
 cpVect cpBBWrapVect(const cpBB bb, const cpVect v); // wrap a vector to a bbox
 
 ///@}
+
+#endif // guard
+

--- a/include/chipmunk/cpBody.h
+++ b/include/chipmunk/cpBody.h
@@ -19,6 +19,9 @@
  * SOFTWARE.
  */
 
+#ifndef CHIPMUNK_BODY_HEADER
+#define CHIPMUNK_BODY_HEADER
+
 /// @defgroup cpBody cpBody
 /// Chipmunk's rigid body type. Rigid bodies hold the physical properties of an object like
 /// it's mass, and position and velocity of it's center of gravity. They don't have an shape on their own.
@@ -249,3 +252,6 @@ typedef void (*cpBodyArbiterIteratorFunc)(cpBody *body, cpArbiter *arbiter, void
 void cpBodyEachArbiter(cpBody *body, cpBodyArbiterIteratorFunc func, void *data);
 
 ///@}
+
+#endif // guard
+

--- a/include/chipmunk/cpPolyShape.h
+++ b/include/chipmunk/cpPolyShape.h
@@ -19,6 +19,9 @@
  * SOFTWARE.
  */
 
+#ifndef CHIPMUNK_POLY_HEADER
+#define CHIPMUNK_POLY_HEADER
+
 /// @defgroup cpPolyShape cpPolyShape
 /// @{
 
@@ -65,3 +68,6 @@ int cpPolyShapeGetNumVerts(cpShape *shape);
 cpVect cpPolyShapeGetVert(cpShape *shape, int idx);
 
 /// @}
+
+#endif // guard
+

--- a/include/chipmunk/cpShape.h
+++ b/include/chipmunk/cpShape.h
@@ -1,15 +1,15 @@
 /* Copyright (c) 2007 Scott Lembcke
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -18,7 +18,10 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
- 
+
+#ifndef CHIPMUNK_SHAPE_HEADER
+#define CHIPMUNK_SHAPE_HEADER
+
 /// @defgroup cpShape cpShape
 /// The cpShape struct defines the shape of a rigid body.
 /// @{
@@ -61,7 +64,7 @@ typedef void (*cpShapeSegmentQueryImpl)(cpShape *shape, cpVect a, cpVect b, cpSe
 /// @private
 struct cpShapeClass {
 	cpShapeType type;
-	
+
 	cpShapeCacheDataImpl cacheData;
 	cpShapeDestroyImpl destroy;
 	cpShapeNearestPointQueryImpl nearestPointQuery;
@@ -71,17 +74,17 @@ struct cpShapeClass {
 /// Opaque collision shape struct.
 struct cpShape {
 	CP_PRIVATE(const cpShapeClass *klass);
-	
+
 	/// The rigid body this collision shape is attached to.
 	cpBody *body;
 
 	/// The current bounding box of the shape.
 	cpBB bb;
-	
+
 	/// Sensor flag.
 	/// Sensor shapes call collision callbacks but don't produce collisions.
 	cpBool sensor;
-	
+
 	/// Coefficient of restitution. (elasticity)
 	cpFloat e;
 	/// Coefficient of friction.
@@ -93,19 +96,19 @@ struct cpShape {
 	/// Generally this points to your the game object class so you can access it
 	/// when given a cpShape reference in a callback.
 	cpDataPointer data;
-	
+
 	/// Collision type of this shape used when picking collision handlers.
 	cpCollisionType collision_type;
 	/// Group of this shape. Shapes in the same group don't collide.
 	cpGroup group;
 	// Layer bitmask for this shape. Shapes only collide if the bitwise and of their layers is non-zero.
 	cpLayers layers;
-	
+
 	CP_PRIVATE(cpSpace *space);
-	
+
 	CP_PRIVATE(cpShape *next);
 	CP_PRIVATE(cpShape *prev);
-	
+
 	CP_PRIVATE(cpHashValue hashid);
 };
 
@@ -182,7 +185,7 @@ void cpResetShapeIdCounter(void);
 /// @private
 typedef struct cpCircleShape {
 	cpShape shape;
-	
+
 	cpVect c, tc;
 	cpFloat r;
 } cpCircleShape;
@@ -203,11 +206,11 @@ CP_DeclareShapeGetter(cpCircleShape, cpFloat, Radius);
 /// @private
 typedef struct cpSegmentShape {
 	cpShape shape;
-	
+
 	cpVect a, b, n;
 	cpVect ta, tb, tn;
 	cpFloat r;
-	
+
 	cpVect a_tangent, b_tangent;
 } cpSegmentShape;
 
@@ -226,3 +229,6 @@ CP_DeclareShapeGetter(cpSegmentShape, cpVect, Normal);
 CP_DeclareShapeGetter(cpSegmentShape, cpFloat, Radius);
 
 /// @}
+
+#endif // guard
+

--- a/include/chipmunk/cpSpace.h
+++ b/include/chipmunk/cpSpace.h
@@ -19,6 +19,9 @@
  * SOFTWARE.
  */
 
+#ifndef CHIPMUNK_SPACE_HEADER
+#define CHIPMUNK_SPACE_HEADER
+
 /// @defgroup cpSpace cpSpace
 /// @{
 
@@ -283,3 +286,6 @@ void cpSpaceUseSpatialHash(cpSpace *space, cpFloat dim, int count);
 void cpSpaceStep(cpSpace *space, cpFloat dt);
 
 /// @}
+
+#endif // guard
+

--- a/include/chipmunk/cpSpatialIndex.h
+++ b/include/chipmunk/cpSpatialIndex.h
@@ -19,6 +19,9 @@
  * SOFTWARE.
  */
 
+#ifndef CHIPMUNK_SPATIALINDEX_HEADER
+#define CHIPMUNK_SPATIALINDEX_HEADER
+
 /**
 	@defgroup cpSpatialIndex cpSpatialIndex
 	
@@ -225,3 +228,6 @@ static inline void cpSpatialIndexReindexQuery(cpSpatialIndex *index, cpSpatialIn
 }
 
 ///@}
+
+#endif // guard
+

--- a/include/chipmunk/cpVect.h
+++ b/include/chipmunk/cpVect.h
@@ -19,6 +19,9 @@
  * SOFTWARE.
  */
 
+#ifndef CHIPMUNK_VECT_HEADER
+#define CHIPMUNK_VECT_HEADER
+
 /// @defgroup cpVect cpVect
 /// Chipmunk's 2D vector type along with a handy 2D vector math lib.
 /// @{
@@ -210,3 +213,6 @@ cpMat2x2Transform(cpMat2x2 m, cpVect v)
 }
 
 ///@}
+
+#endif // guard
+


### PR DESCRIPTION
add some include guards on nearly all public headers. it's very dangerous to not do this, and it will wreak havoc on most projects when they try to use it.

in fact, i don't know how no users caught this earlier, my project's uses witnesses the breakages quite unavoidably.
