### PR TITLE
Add option to force enable blocks on Clang

### DIFF
--- a/Demo/Shatter.c
+++ b/Demo/Shatter.c
@@ -19,10 +19,6 @@
  * SOFTWARE.
  */
  
-#include <stdlib.h>
-#include <string.h>
-#include <stdio.h>
-
 #include "chipmunk.h"
 #include "constraints/util.h"
 


### PR DESCRIPTION
I think this would be pretty convenient for people who like to use blocks outside of OSX and, possibly, porting stuff.
Enabling blocks by itself does not require linking BlocksRuntime, so it is safe to have it enabled by default, at least on my 32bit ArchLinux.
