### PR TITLE
ChipmunkSpace pointQueryNearest effectively returns a ChipmunkShape

### DIFF
--- a/objectivec/include/ObjectiveChipmunk/ChipmunkSpace.h
+++ b/objectivec/include/ObjectiveChipmunk/ChipmunkSpace.h
@@ -200,7 +200,7 @@ typedef void (^ChipmunkPostStepBlock)(void);
 
 /// Find the closest shape to a point that is within @c maxDistance of @c point.
 /// The point is treated as having the given layers and group.
-- (ChipmunkPointQueryInfo *)pointQueryNearest:(cpVect)point maxDistance:(cpFloat)maxDistance filter:(cpShapeFilter)filter;
+- (ChipmunkShape *)pointQueryNearest:(cpVect)point maxDistance:(cpFloat)maxDistance filter:(cpShapeFilter)filter;
 
 /// Return a NSArray of ChipmunkSegmentQueryInfo objects for all the shapes that overlap the segment. The objects are unsorted.
 - (NSArray *)segmentQueryAllFrom:(cpVect)start to:(cpVect)end radius:(cpFloat)radius filter:(cpShapeFilter)filter;


### PR DESCRIPTION
... and not a ChipmunkPointQueryInfo like the header is saying.

BTW, are we allowed to freely use Objective-Chipmunk2D in a project without buying Chipmunk2D Pro ?
