### PR TITLE
includes alloca.h

### DIFF
--- a/src/cpCollision.c
+++ b/src/cpCollision.c
@@ -21,6 +21,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <alloca.h>
 
 #include "chipmunk/chipmunk_private.h"
 


### PR DESCRIPTION
needed for Linux, at least for Linux and my own build
If I don't include it, it won't link.
