### PR TITLE
A warning in Xcode 5.1

### DIFF
--- a/src/cpCollision.c
+++ b/src/cpCollision.c
@@ -250,10 +250,10 @@ ClosestPointsNew(const struct MinkowskiPoint v0, const struct MinkowskiPoint v1)
 		return points;
 	} else {
 		// Vertex/vertex collisions need special treatment since the MSA won't be shared with an axis of the minkowski difference.
-		cpFloat d = cpvlength(p);
-		cpVect n = cpvmult(p, 1.0f/(d + CPFLOAT_MIN));
+		cpFloat d2 = cpvlength(p);
+		cpVect n2 = cpvmult(p, 1.0f/(d2 + CPFLOAT_MIN));
 		
-		struct ClosestPoints points = {pa, pb, n, d, id};
+		struct ClosestPoints points = {pa, pb, n2, d2, id};
 		return points;
 	}
 }


### PR DESCRIPTION
In Mac OS X 10.9 and Xcode 5.1, it is a warning "Declaration shadows a local variable". I have found this in "cocos2d-x" project which uses current project.
