### PR TITLE
Add Code::blocks project file (cbp) for Chipmunk 7

### DIFF
--- a/codeblocks/Chipmunk.cbp
+++ b/codeblocks/Chipmunk.cbp
@@ -1,0 +1,157 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<CodeBlocks_project_file>
+	<FileVersion major="1" minor="6" />
+	<Project>
+		<Option title="Chipmunk" />
+		<Option pch_mode="2" />
+		<Option compiler="gcc" />
+		<Build>
+			<Target title="Debug">
+				<Option output="bin/Debug/libChipmunk" prefix_auto="1" extension_auto="1" />
+				<Option object_output="obj/Debug/" />
+				<Option type="3" />
+				<Option compiler="gcc" />
+				<Option createDefFile="1" />
+				<Option createStaticLib="1" />
+				<Compiler>
+					<Add option="-g" />
+					<Add directory="../include" />
+					<Add directory="../include/chipmunk" />
+				</Compiler>
+			</Target>
+			<Target title="Release">
+				<Option output="bin/Release/libChipmunk" prefix_auto="1" extension_auto="1" />
+				<Option object_output="obj/Release/" />
+				<Option type="3" />
+				<Option compiler="gcc" />
+				<Option createDefFile="1" />
+				<Option createStaticLib="1" />
+				<Compiler>
+					<Add option="-O2" />
+				</Compiler>
+				<Linker>
+					<Add option="-s" />
+				</Linker>
+			</Target>
+		</Build>
+		<Compiler>
+			<Add option="-Wall" />
+			<Add option="-std=c99" />
+		</Compiler>
+		<Unit filename="../include/chipmunk/chipmunk.h" />
+		<Unit filename="../include/chipmunk/chipmunk_ffi.h" />
+		<Unit filename="../include/chipmunk/chipmunk_private.h" />
+		<Unit filename="../include/chipmunk/chipmunk_types.h" />
+		<Unit filename="../include/chipmunk/chipmunk_unsafe.h" />
+		<Unit filename="../include/chipmunk/cpArbiter.h" />
+		<Unit filename="../include/chipmunk/cpBB.h" />
+		<Unit filename="../include/chipmunk/cpBody.h" />
+		<Unit filename="../include/chipmunk/cpConstraint.h" />
+		<Unit filename="../include/chipmunk/cpDampedRotarySpring.h" />
+		<Unit filename="../include/chipmunk/cpDampedSpring.h" />
+		<Unit filename="../include/chipmunk/cpGearJoint.h" />
+		<Unit filename="../include/chipmunk/cpGrooveJoint.h" />
+		<Unit filename="../include/chipmunk/cpPinJoint.h" />
+		<Unit filename="../include/chipmunk/cpPivotJoint.h" />
+		<Unit filename="../include/chipmunk/cpPolyShape.h" />
+		<Unit filename="../include/chipmunk/cpRatchetJoint.h" />
+		<Unit filename="../include/chipmunk/cpRotaryLimitJoint.h" />
+		<Unit filename="../include/chipmunk/cpShape.h" />
+		<Unit filename="../include/chipmunk/cpSimpleMotor.h" />
+		<Unit filename="../include/chipmunk/cpSlideJoint.h" />
+		<Unit filename="../include/chipmunk/cpSpace.h" />
+		<Unit filename="../include/chipmunk/cpSpatialIndex.h" />
+		<Unit filename="../include/chipmunk/cpTransform.h" />
+		<Unit filename="../include/chipmunk/cpVect.h" />
+		<Unit filename="../src/chipmunk.c">
+			<Option compilerVar="CC" />
+		</Unit>
+		<Unit filename="../src/cpArbiter.c">
+			<Option compilerVar="CC" />
+		</Unit>
+		<Unit filename="../src/cpArray.c">
+			<Option compilerVar="CC" />
+		</Unit>
+		<Unit filename="../src/cpBBTree.c">
+			<Option compilerVar="CC" />
+		</Unit>
+		<Unit filename="../src/cpBody.c">
+			<Option compilerVar="CC" />
+		</Unit>
+		<Unit filename="../src/cpCollision.c">
+			<Option compilerVar="CC" />
+		</Unit>
+		<Unit filename="../src/cpConstraint.c">
+			<Option compilerVar="CC" />
+		</Unit>
+		<Unit filename="../src/cpDampedRotarySpring.c">
+			<Option compilerVar="CC" />
+		</Unit>
+		<Unit filename="../src/cpDampedSpring.c">
+			<Option compilerVar="CC" />
+		</Unit>
+		<Unit filename="../src/cpGearJoint.c">
+			<Option compilerVar="CC" />
+		</Unit>
+		<Unit filename="../src/cpGrooveJoint.c">
+			<Option compilerVar="CC" />
+		</Unit>
+		<Unit filename="../src/cpHashSet.c">
+			<Option compilerVar="CC" />
+		</Unit>
+		<Unit filename="../src/cpPinJoint.c">
+			<Option compilerVar="CC" />
+		</Unit>
+		<Unit filename="../src/cpPivotJoint.c">
+			<Option compilerVar="CC" />
+		</Unit>
+		<Unit filename="../src/cpPolyShape.c">
+			<Option compilerVar="CC" />
+		</Unit>
+		<Unit filename="../src/cpRatchetJoint.c">
+			<Option compilerVar="CC" />
+		</Unit>
+		<Unit filename="../src/cpRotaryLimitJoint.c">
+			<Option compilerVar="CC" />
+		</Unit>
+		<Unit filename="../src/cpShape.c">
+			<Option compilerVar="CC" />
+		</Unit>
+		<Unit filename="../src/cpSimpleMotor.c">
+			<Option compilerVar="CC" />
+		</Unit>
+		<Unit filename="../src/cpSlideJoint.c">
+			<Option compilerVar="CC" />
+		</Unit>
+		<Unit filename="../src/cpSpace.c">
+			<Option compilerVar="CC" />
+		</Unit>
+		<Unit filename="../src/cpSpaceComponent.c">
+			<Option compilerVar="CC" />
+		</Unit>
+		<Unit filename="../src/cpSpaceDebug.c">
+			<Option compilerVar="CC" />
+		</Unit>
+		<Unit filename="../src/cpSpaceHash.c">
+			<Option compilerVar="CC" />
+		</Unit>
+		<Unit filename="../src/cpSpaceQuery.c">
+			<Option compilerVar="CC" />
+		</Unit>
+		<Unit filename="../src/cpSpaceStep.c">
+			<Option compilerVar="CC" />
+		</Unit>
+		<Unit filename="../src/cpSpatialIndex.c">
+			<Option compilerVar="CC" />
+		</Unit>
+		<Unit filename="../src/cpSweep1D.c">
+			<Option compilerVar="CC" />
+		</Unit>
+		<Unit filename="../src/prime.h" />
+		<Extensions>
+			<code_completion />
+			<envvars />
+			<debugger />
+		</Extensions>
+	</Project>
+</CodeBlocks_project_file>

--- a/include/chipmunk/chipmunk_private.h
+++ b/include/chipmunk/chipmunk_private.h
@@ -1,15 +1,15 @@
 /* Copyright (c) 2013 Scott Lembcke and Howling Moon Software
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -18,13 +18,11 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
+#ifndef CHIPMUNK_PRIVATE_H
+#define CHIPMUNK_PRIVATE_H
 #ifdef CHIPMUNK_H
 #error Cannot include chipmunk_private.h after chipmunk.h.
 #endif
-
-#ifndef CHIPMUNK_PRIVATE_H
-#define CHIPMUNK_PRIVATE_H
 
 #define CP_ALLOW_PRIVATE_ACCESS 1
 #include "chipmunk.h"
@@ -83,43 +81,43 @@ struct cpBody {
 	// Integration functions
 	cpBodyVelocityFunc velocity_func;
 	cpBodyPositionFunc position_func;
-	
+
 	// mass and it's inverse
 	cpFloat m;
 	cpFloat m_inv;
-	
+
 	// moment of inertia and it's inverse
 	cpFloat i;
 	cpFloat i_inv;
-	
+
 	// center of gravity
 	cpVect cog;
-	
+
 	// position, velocity, force
 	cpVect p;
 	cpVect v;
 	cpVect f;
-	
+
 	// Angle, angular velocity, torque (radians)
 	cpFloat a;
 	cpFloat w;
 	cpFloat t;
-	
+
 	cpTransform transform;
-	
+
 	cpDataPointer userData;
-	
+
 	// "pseudo-velocities" used for eliminating overlap.
 	// Erin Catto has some papers that talk about what these are.
 	cpVect v_bias;
 	cpFloat w_bias;
-	
+
 	cpSpace *space;
-	
+
 	cpShape *shapeList;
 	cpArbiter *arbiterList;
 	cpConstraint *constraintList;
-	
+
 	struct {
 		cpBody *root;
 		cpBody *next;
@@ -163,22 +161,22 @@ struct cpArbiterThread {
 
 struct cpContact {
 	cpVect r1, r2;
-	
+
 	cpFloat nMass, tMass;
 	cpFloat bounce; // TODO: look for an alternate bounce solution.
 
 	cpFloat jnAcc, jtAcc, jBias;
 	cpFloat bias;
-	
+
 	cpHashValue hash;
 };
 
 struct cpCollisionInfo {
 	const cpShape *a, *b;
 	cpCollisionID id;
-	
+
 	cpVect n;
-	
+
 	int count;
 	// TODO Should this be a unique struct type?
 	struct cpContact *arr;
@@ -188,21 +186,21 @@ struct cpArbiter {
 	cpFloat e;
 	cpFloat u;
 	cpVect surface_vr;
-	
+
 	cpDataPointer data;
-	
+
 	const cpShape *a, *b;
 	cpBody *body_a, *body_b;
 	struct cpArbiterThread thread_a, thread_b;
-	
+
 	int count;
 	struct cpContact *contacts;
 	cpVect n;
-	
+
 	// Regular, wildcard A and wildcard B collision handlers.
 	cpCollisionHandler *handler, *handlerA, *handlerB;
 	cpBool swapped;
-	
+
 	cpTimestamp stamp;
 	enum cpArbiterState state;
 };
@@ -248,7 +246,7 @@ typedef struct cpShapeClass cpShapeClass;
 
 struct cpShapeClass {
 	cpShapeType type;
-	
+
 	cpShapeCacheDataImpl cacheData;
 	cpShapeDestroyImpl destroy;
 	cpShapePointQueryImpl pointQuery;
@@ -257,43 +255,43 @@ struct cpShapeClass {
 
 struct cpShape {
 	const cpShapeClass *klass;
-	
+
 	cpSpace *space;
 	cpBody *body;
 	struct cpShapeMassInfo massInfo;
 	cpBB bb;
-	
+
 	cpBool sensor;
-	
+
 	cpFloat e;
 	cpFloat u;
 	cpVect surfaceV;
 
 	cpDataPointer userData;
-	
+
 	cpCollisionType type;
 	cpShapeFilter filter;
-	
+
 	cpShape *next;
 	cpShape *prev;
-	
+
 	cpHashValue hashid;
 };
 
 struct cpCircleShape {
 	cpShape shape;
-	
+
 	cpVect c, tc;
 	cpFloat r;
 };
 
 struct cpSegmentShape {
 	cpShape shape;
-	
+
 	cpVect a, b, n;
 	cpVect ta, tb, tn;
 	cpFloat r;
-	
+
 	cpVect a_tangent, b_tangent;
 };
 
@@ -305,13 +303,13 @@ struct cpSplittingPlane {
 
 struct cpPolyShape {
 	cpShape shape;
-	
+
 	cpFloat r;
-	
+
 	int count;
 	// The untransformed planes are appended at the end of the transformed planes.
 	struct cpSplittingPlane *planes;
-	
+
 	// Allocate a small number of splitting planes internally for simple poly.
 	struct cpSplittingPlane _planes[2*CP_POLY_SHAPE_INLINE_ALLOC];
 };
@@ -335,16 +333,16 @@ CircleSegmentQuery(cpShape *shape, cpVect center, cpFloat r1, cpVect a, cpVect b
 	cpVect da = cpvsub(a, center);
 	cpVect db = cpvsub(b, center);
 	cpFloat rsum = r1 + r2;
-	
+
 	cpFloat qa = cpvdot(da, da) - 2.0f*cpvdot(da, db) + cpvdot(db, db);
 	cpFloat qb = cpvdot(da, db) - cpvdot(da, da);
 	cpFloat det = qb*qb - qa*(cpvdot(da, da) - rsum*rsum);
-	
+
 	if(det >= 0.0f){
 		cpFloat t = (-qb - cpfsqrt(det))/(qa);
 		if(0.0f<= t && t <= 1.0f){
 			cpVect n = cpvnormalize(cpvlerp(da, db, t));
-			
+
 			info->shape = shape;
 			info->point = cpvsub(cpvlerp(a, b, t), cpvmult(n, r2));
 			info->normal = n;
@@ -386,21 +384,21 @@ typedef struct cpConstraintClass {
 
 struct cpConstraint {
 	const cpConstraintClass *klass;
-	
+
 	cpSpace *space;
-	
+
 	cpBody *a, *b;
 	cpConstraint *next_a, *next_b;
-	
+
 	cpFloat maxForce;
 	cpFloat errorBias;
 	cpFloat maxBias;
-	
+
 	cpBool collideBodies;
-	
+
 	cpConstraintPreSolveFunc preSolve;
 	cpConstraintPostSolveFunc postSolve;
-	
+
 	cpDataPointer userData;
 };
 
@@ -408,11 +406,11 @@ struct cpPinJoint {
 	cpConstraint constraint;
 	cpVect anchorA, anchorB;
 	cpFloat dist;
-	
+
 	cpVect r1, r2;
 	cpVect n;
 	cpFloat nMass;
-	
+
 	cpFloat jnAcc;
 	cpFloat bias;
 };
@@ -421,11 +419,11 @@ struct cpSlideJoint {
 	cpConstraint constraint;
 	cpVect anchorA, anchorB;
 	cpFloat min, max;
-	
+
 	cpVect r1, r2;
 	cpVect n;
 	cpFloat nMass;
-	
+
 	cpFloat jnAcc;
 	cpFloat bias;
 };
@@ -433,10 +431,10 @@ struct cpSlideJoint {
 struct cpPivotJoint {
 	cpConstraint constraint;
 	cpVect anchorA, anchorB;
-	
+
 	cpVect r1, r2;
 	cpMat2x2 k;
-	
+
 	cpVect jAcc;
 	cpVect bias;
 };
@@ -445,12 +443,12 @@ struct cpGrooveJoint {
 	cpConstraint constraint;
 	cpVect grv_n, grv_a, grv_b;
 	cpVect  anchorB;
-	
+
 	cpVect grv_tn;
 	cpFloat clamp;
 	cpVect r1, r2;
 	cpMat2x2 k;
-	
+
 	cpVect jAcc;
 	cpVect bias;
 };
@@ -462,14 +460,14 @@ struct cpDampedSpring {
 	cpFloat stiffness;
 	cpFloat damping;
 	cpDampedSpringForceFunc springForceFunc;
-	
+
 	cpFloat target_vrn;
 	cpFloat v_coef;
-	
+
 	cpVect r1, r2;
 	cpFloat nMass;
 	cpVect n;
-	
+
 	cpFloat jAcc;
 };
 
@@ -479,10 +477,10 @@ struct cpDampedRotarySpring {
 	cpFloat stiffness;
 	cpFloat damping;
 	cpDampedRotarySpringTorqueFunc springTorqueFunc;
-	
+
 	cpFloat target_wrn;
 	cpFloat w_coef;
-	
+
 	cpFloat iSum;
 	cpFloat jAcc;
 };
@@ -490,9 +488,9 @@ struct cpDampedRotarySpring {
 struct cpRotaryLimitJoint {
 	cpConstraint constraint;
 	cpFloat min, max;
-	
+
 	cpFloat iSum;
-		
+
 	cpFloat bias;
 	cpFloat jAcc;
 };
@@ -500,9 +498,9 @@ struct cpRotaryLimitJoint {
 struct cpRatchetJoint {
 	cpConstraint constraint;
 	cpFloat angle, phase, ratchet;
-	
+
 	cpFloat iSum;
-		
+
 	cpFloat bias;
 	cpFloat jAcc;
 };
@@ -511,9 +509,9 @@ struct cpGearJoint {
 	cpConstraint constraint;
 	cpFloat phase, ratio;
 	cpFloat ratio_inv;
-	
+
 	cpFloat iSum;
-		
+
 	cpFloat bias;
 	cpFloat jAcc;
 };
@@ -521,9 +519,9 @@ struct cpGearJoint {
 struct cpSimpleMotor {
 	cpConstraint constraint;
 	cpFloat rate;
-	
+
 	cpFloat iSum;
-		
+
 	cpFloat jAcc;
 };
 
@@ -540,7 +538,7 @@ static inline cpVect
 relative_velocity(cpBody *a, cpBody *b, cpVect r1, cpVect r2){
 	cpVect v1_sum = cpvadd(a->CP_PRIVATE(v), cpvmult(cpvperp(r1), a->CP_PRIVATE(w)));
 	cpVect v2_sum = cpvadd(b->CP_PRIVATE(v), cpvmult(cpvperp(r2), b->CP_PRIVATE(w)));
-	
+
 	return cpvsub(v2_sum, v1_sum);
 }
 
@@ -588,7 +586,7 @@ k_scalar(cpBody *a, cpBody *b, cpVect r1, cpVect r2, cpVect n)
 {
 	cpFloat value = k_scalar_body(a, r1, n) + k_scalar_body(b, r2, n);
 	cpAssertSoft(value != 0.0, "Unsolvable collision or constraint.");
-	
+
 	return value;
 }
 
@@ -596,11 +594,11 @@ static inline cpMat2x2
 k_tensor(cpBody *a, cpBody *b, cpVect r1, cpVect r2)
 {
 	cpFloat m_sum = a->CP_PRIVATE(m_inv) + b->CP_PRIVATE(m_inv);
-	
+
 	// start with Identity*m_sum
 	cpFloat k11 = m_sum, k12 = 0.0f;
 	cpFloat k21 = 0.0f,  k22 = m_sum;
-	
+
 	// add the influence from r1
 	cpFloat a_i_inv = a->CP_PRIVATE(i_inv);
 	cpFloat r1xsq =  r1.x * r1.x * a_i_inv;
@@ -608,7 +606,7 @@ k_tensor(cpBody *a, cpBody *b, cpVect r1, cpVect r2)
 	cpFloat r1nxy = -r1.x * r1.y * a_i_inv;
 	k11 += r1ysq; k12 += r1nxy;
 	k21 += r1nxy; k22 += r1xsq;
-	
+
 	// add the influnce from r2
 	cpFloat b_i_inv = b->CP_PRIVATE(i_inv);
 	cpFloat r2xsq =  r2.x * r2.x * b_i_inv;
@@ -616,11 +614,11 @@ k_tensor(cpBody *a, cpBody *b, cpVect r1, cpVect r2)
 	cpFloat r2nxy = -r2.x * r2.y * b_i_inv;
 	k11 += r2ysq; k12 += r2nxy;
 	k21 += r2nxy; k22 += r2xsq;
-	
+
 	// invert
 	cpFloat det = k11*k22 - k12*k21;
 	cpAssertSoft(det != 0.0, "Unsolvable constraint.");
-	
+
 	cpFloat det_inv = 1.0f/det;
 	return cpMat2x2New(
 		 k22*det_inv, -k12*det_inv,
@@ -639,19 +637,19 @@ bias_coef(cpFloat errorBias, cpFloat dt)
 
 struct cpSpace {
 	int iterations;
-	
+
 	cpVect gravity;
 	cpFloat damping;
-	
+
 	cpFloat idleSpeedThreshold;
 	cpFloat sleepTimeThreshold;
-	
+
 	cpFloat collisionSlop;
 	cpFloat collisionBias;
 	cpTimestamp collisionPersistence;
-	
+
 	cpDataPointer userData;
-	
+
 	cpTimestamp stamp;
 	cpFloat curr_dt;
 
@@ -659,28 +657,28 @@ struct cpSpace {
 	cpArray *staticBodies;
 	cpArray *rousedBodies;
 	cpArray *sleepingComponents;
-	
+
 	cpHashValue shapeIDCounter;
 	cpSpatialIndex *staticShapes;
 	cpSpatialIndex *dynamicShapes;
-	
+
 	cpArray *constraints;
-	
+
 	cpArray *arbiters;
 	cpContactBufferHeader *contactBuffersHead;
 	cpHashSet *cachedArbiters;
 	cpArray *pooledArbiters;
-	
+
 	cpArray *allocatedBuffers;
 	unsigned int locked;
-	
+
 	cpBool usesWildcards;
 	cpHashSet *collisionHandlers;
 	cpCollisionHandler defaultHandler;
-	
+
 	cpBool skipPostStep;
 	cpArray *postStepCallbacks;
-	
+
 	cpBody *staticBody;
 	cpBody _staticBody;
 };

--- a/include/chipmunk/cpSpace.h
+++ b/include/chipmunk/cpSpace.h
@@ -1,15 +1,15 @@
 /* Copyright (c) 2013 Scott Lembcke and Howling Moon Software
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -40,7 +40,7 @@ typedef void (*cpCollisionPostSolveFunc)(cpArbiter *arb, cpSpace *space, cpDataP
 typedef void (*cpCollisionSeparateFunc)(cpArbiter *arb, cpSpace *space, cpDataPointer userData);
 
 struct cpCollisionHandler {
-	const cpCollisionType typeA, typeB;
+	cpCollisionType typeA, typeB;
 	cpCollisionBeginFunc beginFunc;
 	cpCollisionPreSolveFunc preSolveFunc;
 	cpCollisionPostSolveFunc postSolveFunc;
@@ -267,13 +267,13 @@ typedef struct cpSpaceDebugDrawOptions {
 	cpSpaceDebugDrawFatSegmentImpl drawFatSegment;
 	cpSpaceDebugDrawPolygonImpl drawPolygon;
 	cpSpaceDebugDrawDotImpl drawDot;
-	
+
 	cpSpaceDebugDrawFlags flags;
 	cpSpaceDebugColor shapeOutlineColor;
 	cpSpaceDebugDrawColorForShapeImpl colorForShape;
 	cpSpaceDebugColor constraintColor;
 	cpSpaceDebugColor collisionPointColor;
-	
+
 	cpDataPointer data;
 } cpSpaceDebugDrawOptions;
 


### PR DESCRIPTION
Add Code::blocks project file (cbp) for Chipmunk 7, and 2 fixes for compilation and usage:
- const for the first data fields in cpCollisionHandler cause compilation
  errors on MinGW, not sure why but just remove const fixes it
- including chipmunk_private.h the second time would cause error because
  it checks if chipmunk.h has been included right in the beginning.
  basically just add a guard ifdef CHIPMUNK_PRIVATE_H_INCLUDED to the
  start of the file to fix
