### PR TITLE
Move cpArbiter.h include before cpShape.h

### DIFF
--- a/include/chipmunk/chipmunk.h
+++ b/include/chipmunk/chipmunk.h
@@ -125,12 +125,12 @@ typedef struct cpSpace cpSpace;
 #include "cpTransform.h"
 #include "cpSpatialIndex.h"
 
+#include "cpArbiter.h"
+#include "cpConstraint.h"
+
 #include "cpBody.h"
 #include "cpShape.h"
 #include "cpPolyShape.h"
-
-#include "cpArbiter.h"	
-#include "cpConstraint.h"
 
 #include "cpSpace.h"
 


### PR DESCRIPTION
This fixes a C-Linkage error when included from C++. See: slembcke#71
