### PR TITLE
Fixes to compile with Visual Studio, and as a .dll

### DIFF
--- a/include/chipmunk/chipmunk_types.h
+++ b/include/chipmunk/chipmunk_types.h
@@ -5,6 +5,11 @@
    #include "TargetConditionals.h"
 #endif
 
+/* For piece of junk Visual Studio */
+#if defined(_MSC_VER)
+	#define inline __inline
+#endif
+
 #if ((TARGET_OS_IPHONE == 1) || (TARGET_OS_MAC == 1)) && (!defined CP_USE_CGPOINTS)
 	#define CP_USE_CGPOINTS 1
 #endif

--- a/include/chipmunk/constraints/cpConstraint.h
+++ b/include/chipmunk/constraints/cpConstraint.h
@@ -90,8 +90,10 @@ void cpConstraintFree(cpConstraint *constraint);
 /// @private
 static inline void cpConstraintActivateBodies(cpConstraint *constraint)
 {
-	cpBody *a = constraint->a; if(a) cpBodyActivate(a);
-	cpBody *b = constraint->b; if(b) cpBodyActivate(b);
+	cpBody *a;
+	cpBody *b;
+	a = constraint->a; if(a) cpBodyActivate(a);
+	b = constraint->b; if(b) cpBodyActivate(b);
 }
 
 /// @private

--- a/msvc/vc12/chipmunk/chipmunk.def
+++ b/msvc/vc12/chipmunk/chipmunk.def
@@ -25,6 +25,7 @@ EXPORTS
 	cpBodyActivate
 	cpBodyActivateStatic
 	cpBodyAlloc
+	cpBodyApplyImpulse
 	cpBodyDestroy
 	cpBodyEachArbiter
 	cpBodyFree
@@ -169,3 +170,57 @@ EXPORTS
 	cpvslerp
 	cpvslerpconst
 	cpvstr
+
+	cpBodyResetForces
+	cpBodyApplyForce
+	cpBodyGetVelAtLocalPoint
+	cpBodyEachShape
+	cpBodyEachConstraint
+	cpCircleShapeGetOffset
+	cpCircleShapeGetRadius
+	cpSegmentShapeGetA
+	cpSegmentShapeGetB
+	cpSegmentShapeGetNormal
+	cpSegmentShapeGetRadius
+	cpArbiterGetSurfaceVelocity
+	cpArbiterSetSurfaceVelocity
+	cpArbiterSetContactPointSet
+	cpConstraintDestroy
+	cpPinJointAlloc
+	cpPinJointInit
+	cpSlideJointAlloc
+	cpSlideJointInit
+	cpPivotJointAlloc
+	cpPivotJointInit
+	cpGrooveJointAlloc
+	cpGrooveJointInit
+	cpGrooveJointSetGrooveA
+	cpGrooveJointSetGrooveB
+	cpDampedSpringAlloc
+	cpDampedSpringInit
+	cpDampedRotarySpringGetClass
+	cpDampedRotarySpringAlloc
+	cpDampedRotarySpringInit
+	cpRotaryLimitJointGetClass
+	cpRotaryLimitJointAlloc
+	cpRotaryLimitJointInit
+	cpRatchetJointGetClass
+	cpRatchetJointAlloc
+	cpRatchetJointInit
+	cpGearJointGetClass
+	cpGearJointAlloc
+	cpGearJointInit
+	cpGearJointSetRatio
+	cpSimpleMotorAlloc
+	cpSimpleMotorInit
+	cpSpaceConvertBodyToStatic
+	cpSpaceConvertBodyToDynamic
+	cpInitChipmunk
+	cpEnableSegmentToSegmentCollisions
+	cpAreaForCircle
+	cpAreaForSegment
+	cpRecenterPoly
+	cpVersionString
+
+
+


### PR DESCRIPTION
This is against the 6.2.x branch.


1) The use of C99 inline by calling projects breaks the compile. This is because Visual Studio is a piece of junk and hasn't updated their C compliance in 25 years. Here is a workaround.

#if defined(_MSC_VER)
	#define inline __inline
#endif

2) cpConstraintActivateBodies in cpConstraint.h can't handle declaring cpBody *b after the first line because Visual Studio's C89 compiler can't handle C99 declaring variables anywhere in the function.

3) The chipmunk.def is out of date and not all the symbols are being exported.
These were all found by brute force. I did not look for removed APIs.