### PR TITLE
Fix chipmunk_private.h include

### DIFF
--- a/src/chipmunk.c
+++ b/src/chipmunk.c
@@ -23,7 +23,7 @@
 #include <string.h>
 #include <stdarg.h>
 
-#include "chipmunk/chipmunk_private.h"
+#include "chipmunk_private.h"
 
 void
 cpMessage(const char *condition, const char *file, int line, int isError, int isHardError, const char *message, ...)

--- a/src/cpArbiter.c
+++ b/src/cpArbiter.c
@@ -19,7 +19,7 @@
  * SOFTWARE.
  */
 
-#include "chipmunk/chipmunk_private.h"
+#include "chipmunk_private.h"
 
 // TODO: make this generic so I can reuse it for constraints also.
 static inline void

--- a/src/cpArray.c
+++ b/src/cpArray.c
@@ -21,7 +21,7 @@
 
 #include <string.h>
 
-#include "chipmunk/chipmunk_private.h"
+#include "chipmunk_private.h"
 
 
 cpArray *

--- a/src/cpBBTree.c
+++ b/src/cpBBTree.c
@@ -22,7 +22,7 @@
 #include "stdlib.h"
 #include "stdio.h"
 
-#include "chipmunk/chipmunk_private.h"
+#include "chipmunk_private.h"
 
 static inline cpSpatialIndexClass *Klass();
 

--- a/src/cpBody.c
+++ b/src/cpBody.c
@@ -22,7 +22,7 @@
 #include <float.h>
 #include <stdarg.h>
 
-#include "chipmunk/chipmunk_private.h"
+#include "chipmunk_private.h"
 
 cpBody*
 cpBodyAlloc(void)

--- a/src/cpCollision.c
+++ b/src/cpCollision.c
@@ -22,7 +22,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "chipmunk/chipmunk_private.h"
+#include "chipmunk_private.h"
 
 #if DEBUG && 0
 #include "ChipmunkDemo.h"

--- a/src/cpConstraint.c
+++ b/src/cpConstraint.c
@@ -19,7 +19,7 @@
  * SOFTWARE.
  */
 
-#include "chipmunk/chipmunk_private.h"
+#include "chipmunk_private.h"
 
 // TODO: Comment me!
 

--- a/src/cpDampedRotarySpring.c
+++ b/src/cpDampedRotarySpring.c
@@ -19,7 +19,7 @@
  * SOFTWARE.
  */
 
-#include "chipmunk/chipmunk_private.h"
+#include "chipmunk_private.h"
 
 static cpFloat
 defaultSpringTorque(cpDampedRotarySpring *spring, cpFloat relativeAngle){

--- a/src/cpDampedSpring.c
+++ b/src/cpDampedSpring.c
@@ -19,7 +19,7 @@
  * SOFTWARE.
  */
 
-#include "chipmunk/chipmunk_private.h"
+#include "chipmunk_private.h"
 
 static cpFloat
 defaultSpringForce(cpDampedSpring *spring, cpFloat dist){

--- a/src/cpGearJoint.c
+++ b/src/cpGearJoint.c
@@ -19,7 +19,7 @@
  * SOFTWARE.
  */
 
-#include "chipmunk/chipmunk_private.h"
+#include "chipmunk_private.h"
 
 static void
 preStep(cpGearJoint *joint, cpFloat dt)

--- a/src/cpGrooveJoint.c
+++ b/src/cpGrooveJoint.c
@@ -19,7 +19,7 @@
  * SOFTWARE.
  */
 
-#include "chipmunk/chipmunk_private.h"
+#include "chipmunk_private.h"
 
 static void
 preStep(cpGrooveJoint *joint, cpFloat dt)

--- a/src/cpHashSet.c
+++ b/src/cpHashSet.c
@@ -19,7 +19,7 @@
  * SOFTWARE.
  */
 
-#include "chipmunk/chipmunk_private.h"
+#include "chipmunk_private.h"
 #include "prime.h"
 
 typedef struct cpHashSetBin {

--- a/src/cpPinJoint.c
+++ b/src/cpPinJoint.c
@@ -19,7 +19,7 @@
  * SOFTWARE.
  */
 
-#include "chipmunk/chipmunk_private.h"
+#include "chipmunk_private.h"
 
 static void
 preStep(cpPinJoint *joint, cpFloat dt)

--- a/src/cpPivotJoint.c
+++ b/src/cpPivotJoint.c
@@ -19,7 +19,7 @@
  * SOFTWARE.
  */
 
-#include "chipmunk/chipmunk_private.h"
+#include "chipmunk_private.h"
 
 static void
 preStep(cpPivotJoint *joint, cpFloat dt)

--- a/src/cpPolyShape.c
+++ b/src/cpPolyShape.c
@@ -19,7 +19,7 @@
  * SOFTWARE.
  */
 
-#include "chipmunk/chipmunk_private.h"
+#include "chipmunk_private.h"
 #include "chipmunk_unsafe.h"
 
 cpPolyShape *

--- a/src/cpRatchetJoint.c
+++ b/src/cpRatchetJoint.c
@@ -19,7 +19,7 @@
  * SOFTWARE.
  */
 
-#include "chipmunk/chipmunk_private.h"
+#include "chipmunk_private.h"
 
 static void
 preStep(cpRatchetJoint *joint, cpFloat dt)

--- a/src/cpRotaryLimitJoint.c
+++ b/src/cpRotaryLimitJoint.c
@@ -19,7 +19,7 @@
  * SOFTWARE.
  */
 
-#include "chipmunk/chipmunk_private.h"
+#include "chipmunk_private.h"
 
 static void
 preStep(cpRotaryLimitJoint *joint, cpFloat dt)

--- a/src/cpShape.c
+++ b/src/cpShape.c
@@ -19,7 +19,7 @@
  * SOFTWARE.
  */
 
-#include "chipmunk/chipmunk_private.h"
+#include "chipmunk_private.h"
 #include "chipmunk_unsafe.h"
 
 #define CP_DefineShapeGetter(struct, type, member, name) \

--- a/src/cpSimpleMotor.c
+++ b/src/cpSimpleMotor.c
@@ -19,7 +19,7 @@
  * SOFTWARE.
  */
 
-#include "chipmunk/chipmunk_private.h"
+#include "chipmunk_private.h"
 
 static void
 preStep(cpSimpleMotor *joint, cpFloat dt)

--- a/src/cpSlideJoint.c
+++ b/src/cpSlideJoint.c
@@ -19,7 +19,7 @@
  * SOFTWARE.
  */
 
-#include "chipmunk/chipmunk_private.h"
+#include "chipmunk_private.h"
 
 static void
 preStep(cpSlideJoint *joint, cpFloat dt)

--- a/src/cpSpace.c
+++ b/src/cpSpace.c
@@ -22,7 +22,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "chipmunk/chipmunk_private.h"
+#include "chipmunk_private.h"
 
 //MARK: Contact Set Helpers
 

--- a/src/cpSpaceComponent.c
+++ b/src/cpSpaceComponent.c
@@ -21,7 +21,7 @@
  
 #include <string.h>
 
-#include "chipmunk/chipmunk_private.h"
+#include "chipmunk_private.h"
 
 //MARK: Sleeping Functions
 

--- a/src/cpSpaceDebug.c
+++ b/src/cpSpaceDebug.c
@@ -19,7 +19,7 @@
  * SOFTWARE.
  */
 
-#include "chipmunk/chipmunk_private.h"
+#include "chipmunk_private.h"
 
 #ifndef CP_SPACE_DISABLE_DEBUG_API
 

--- a/src/cpSpaceHash.c
+++ b/src/cpSpaceHash.c
@@ -19,7 +19,7 @@
  * SOFTWARE.
  */
 
-#include "chipmunk/chipmunk_private.h"
+#include "chipmunk_private.h"
 #include "prime.h"
 
 typedef struct cpSpaceHashBin cpSpaceHashBin;

--- a/src/cpSpaceQuery.c
+++ b/src/cpSpaceQuery.c
@@ -19,7 +19,7 @@
  * SOFTWARE.
  */
 
-#include "chipmunk/chipmunk_private.h"
+#include "chipmunk_private.h"
 
 //MARK: Nearest Point Query Functions
 

--- a/src/cpSpaceStep.c
+++ b/src/cpSpaceStep.c
@@ -19,7 +19,7 @@
  * SOFTWARE.
  */
 
-#include "chipmunk/chipmunk_private.h"
+#include "chipmunk_private.h"
 
 //MARK: Post Step Callback Functions
 

--- a/src/cpSpatialIndex.c
+++ b/src/cpSpatialIndex.c
@@ -19,7 +19,7 @@
  * SOFTWARE.
  */
 
-#include "chipmunk/chipmunk_private.h"
+#include "chipmunk_private.h"
 
 void
 cpSpatialIndexFree(cpSpatialIndex *index)

--- a/src/cpSweep1D.c
+++ b/src/cpSweep1D.c
@@ -19,7 +19,7 @@
  * SOFTWARE.
  */
 
-#include "chipmunk/chipmunk_private.h"
+#include "chipmunk_private.h"
 
 static inline cpSpatialIndexClass *Klass();
 


### PR DESCRIPTION
Compilation fails without this patch. In src/CMakeList.txt, the include dir already contains `chipmunk/`, causing search to fail here.