### PR TITLE
Made Chipmunk compile properly in FreeBSD.

### DIFF
--- a/demo/CMakeLists.txt
+++ b/demo/CMakeLists.txt
@@ -27,6 +27,10 @@ if(NOT MSVC)
   list(APPEND chipmunk_demos_libraries m)
 endif(NOT MSVC)
 
+if(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
+  list(APPEND chipmunk_demos_libraries BlocksRuntime)
+endif(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
+
 file(GLOB chipmunk_demos_source_files "*.c")
 
 include_directories(${chipmunk_demos_include_dirs})

--- a/include/chipmunk/chipmunk.h
+++ b/include/chipmunk/chipmunk.h
@@ -32,6 +32,8 @@
 #ifdef WIN32
 	// For alloca().
 	#include <malloc.h>
+#elif defined(__FreeBSD__)
+	/* already included in <stdlib.h> */
 #else
 	#include <alloca.h>
 #endif


### PR DESCRIPTION
There were two problems in FreeBSD:

1. FreeBSD does not have `<malloc.h>` *or* `<alloca.h>`. It includes the (non-standard, by the way) `alloca()` function in `<stdlib.h>`.
2. `clang` in FreeBSD *does* support blocks, but you need to explicitly link with a library for them here (I've learned that this is true for every system where blocks are not native part of the OS --- in other words, any non-OS-X system and even some older OS X versions). The library is `libBlocksRuntime.so` in FreeBSD's case, so I've added linking with that.

I still can't get the demo program to run, but it *does* compile. I'll create a new pull request if/when I figure out why it doesn't work (`glXCreateNewContext` segfaults for some reason).

Semi-relevant side-note: The most portable way to check for Windows is `#ifdef _WIN32`. I've used `__WIN32__` for quite some time, myself, but it seems that `_WIN32` is supported by literally every compiler (as Microsoft recommends that particular macro), but `WIN32` or `__WIN32__` only by some.