### PR TITLE
Visual Studio Fixes: File path, include path, etc

### DIFF
--- a/msvc/vc12/chipmunk/chipmunk.vcxproj
+++ b/msvc/vc12/chipmunk/chipmunk.vcxproj
@@ -27,22 +27,23 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\..\..\include\chipmunk\chipmunk_private.h" />
+    <ClInclude Include="..\..\..\include\chipmunk\cpConstraint.h" />
+    <ClInclude Include="..\..\..\include\chipmunk\cpDampedRotarySpring.h" />
+    <ClInclude Include="..\..\..\include\chipmunk\cpDampedSpring.h" />
+    <ClInclude Include="..\..\..\include\chipmunk\cpGearJoint.h" />
+    <ClInclude Include="..\..\..\include\chipmunk\cpGrooveJoint.h" />
+    <ClInclude Include="..\..\..\include\chipmunk\cpPinJoint.h" />
+    <ClInclude Include="..\..\..\include\chipmunk\cpPivotJoint.h" />
+    <ClInclude Include="..\..\..\include\chipmunk\cpRatchetJoint.h" />
+    <ClInclude Include="..\..\..\include\chipmunk\cpRotaryLimitJoint.h" />
+    <ClInclude Include="..\..\..\include\chipmunk\cpSimpleMotor.h" />
+    <ClInclude Include="..\..\..\include\chipmunk\cpSlideJoint.h" />
+    <ClInclude Include="..\..\..\include\chipmunk\cpTransform.h" />
     <ClInclude Include="..\..\..\include\chipmunk\chipmunk.h" />
     <ClInclude Include="..\..\..\include\chipmunk\chipmunk_ffi.h" />
     <ClInclude Include="..\..\..\include\chipmunk\chipmunk_types.h" />
     <ClInclude Include="..\..\..\include\chipmunk\chipmunk_unsafe.h" />
-    <ClInclude Include="..\..\..\include\chipmunk\constraints\cpConstraint.h" />
-    <ClInclude Include="..\..\..\include\chipmunk\constraints\cpDampedRotarySpring.h" />
-    <ClInclude Include="..\..\..\include\chipmunk\constraints\cpDampedSpring.h" />
-    <ClInclude Include="..\..\..\include\chipmunk\constraints\cpGearJoint.h" />
-    <ClInclude Include="..\..\..\include\chipmunk\constraints\cpGrooveJoint.h" />
-    <ClInclude Include="..\..\..\include\chipmunk\constraints\cpPinJoint.h" />
-    <ClInclude Include="..\..\..\include\chipmunk\constraints\cpPivotJoint.h" />
-    <ClInclude Include="..\..\..\include\chipmunk\constraints\cpRatchetJoint.h" />
-    <ClInclude Include="..\..\..\include\chipmunk\constraints\cpRotaryLimitJoint.h" />
-    <ClInclude Include="..\..\..\include\chipmunk\constraints\cpSimpleMotor.h" />
-    <ClInclude Include="..\..\..\include\chipmunk\constraints\cpSlideJoint.h" />
-    <ClInclude Include="..\..\..\include\chipmunk\constraints\util.h" />
     <ClInclude Include="..\..\..\include\chipmunk\cpArbiter.h" />
     <ClInclude Include="..\..\..\include\chipmunk\cpBB.h" />
     <ClInclude Include="..\..\..\include\chipmunk\cpBody.h" />
@@ -54,21 +55,21 @@
     <ClInclude Include="..\..\..\src\prime.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\..\src\cpConstraint.c" />
+    <ClCompile Include="..\..\..\src\cpDampedRotarySpring.c" />
+    <ClCompile Include="..\..\..\src\cpDampedSpring.c" />
+    <ClCompile Include="..\..\..\src\cpGearJoint.c" />
+    <ClCompile Include="..\..\..\src\cpGrooveJoint.c" />
+    <ClCompile Include="..\..\..\src\cpPinJoint.c" />
+    <ClCompile Include="..\..\..\src\cpPivotJoint.c" />
+    <ClCompile Include="..\..\..\src\cpRatchetJoint.c" />
+    <ClCompile Include="..\..\..\src\cpRotaryLimitJoint.c" />
+    <ClCompile Include="..\..\..\src\cpSimpleMotor.c" />
+    <ClCompile Include="..\..\..\src\cpSlideJoint.c" />
+    <ClCompile Include="..\..\..\src\cpSpaceDebug.c" />
     <ClCompile Include="..\..\..\src\chipmunk.c" />
-    <ClCompile Include="..\..\..\src\constraints\cpConstraint.c" />
-    <ClCompile Include="..\..\..\src\constraints\cpDampedRotarySpring.c" />
-    <ClCompile Include="..\..\..\src\constraints\cpDampedSpring.c" />
-    <ClCompile Include="..\..\..\src\constraints\cpGearJoint.c" />
-    <ClCompile Include="..\..\..\src\constraints\cpGrooveJoint.c" />
-    <ClCompile Include="..\..\..\src\constraints\cpPinJoint.c" />
-    <ClCompile Include="..\..\..\src\constraints\cpPivotJoint.c" />
-    <ClCompile Include="..\..\..\src\constraints\cpRatchetJoint.c" />
-    <ClCompile Include="..\..\..\src\constraints\cpRotaryLimitJoint.c" />
-    <ClCompile Include="..\..\..\src\constraints\cpSimpleMotor.c" />
-    <ClCompile Include="..\..\..\src\constraints\cpSlideJoint.c" />
     <ClCompile Include="..\..\..\src\cpArbiter.c" />
     <ClCompile Include="..\..\..\src\cpArray.c" />
-    <ClCompile Include="..\..\..\src\cpBB.c" />
     <ClCompile Include="..\..\..\src\cpBBTree.c" />
     <ClCompile Include="..\..\..\src\cpBody.c" />
     <ClCompile Include="..\..\..\src\cpCollision.c" />
@@ -82,7 +83,6 @@
     <ClCompile Include="..\..\..\src\cpSpaceStep.c" />
     <ClCompile Include="..\..\..\src\cpSpatialIndex.c" />
     <ClCompile Include="..\..\..\src\cpSweep1D.c" />
-    <ClCompile Include="..\..\..\src\cpVect.c" />
   </ItemGroup>
   <ItemGroup>
     <None Include="chipmunk.def" />
@@ -177,8 +177,10 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\..\include\chipmunk</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\include</AdditionalIncludeDirectories>
       <CompileAs>CompileAsCpp</CompileAs>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <MinimalRebuild>false</MinimalRebuild>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -190,9 +192,11 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\..\include\chipmunk</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\include</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <CompileAs>CompileAsCpp</CompileAs>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <MinimalRebuild>false</MinimalRebuild>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -204,8 +208,10 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\..\include\chipmunk</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\include</AdditionalIncludeDirectories>
       <CompileAs>CompileAsCpp</CompileAs>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <MinimalRebuild>false</MinimalRebuild>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -219,8 +225,9 @@
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\..\include\chipmunk</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\include</AdditionalIncludeDirectories>
       <CompileAs>CompileAsCpp</CompileAs>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -235,9 +242,10 @@
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\..\include\chipmunk</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\include</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <CompileAs>CompileAsCpp</CompileAs>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -252,8 +260,9 @@
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\..\include\chipmunk</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\include</AdditionalIncludeDirectories>
       <CompileAs>CompileAsCpp</CompileAs>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/msvc/vc12/chipmunk/chipmunk.vcxproj.filters
+++ b/msvc/vc12/chipmunk/chipmunk.vcxproj.filters
@@ -11,12 +11,6 @@
       <Extensions>
       </Extensions>
     </Filter>
-    <Filter Include="include\constraints">
-      <UniqueIdentifier>{2af6495e-94a8-4200-8b69-e531cfdb9518}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="src\constraints">
-      <UniqueIdentifier>{23a179d1-3a41-426c-8528-edba78d4969c}</UniqueIdentifier>
-    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\include\chipmunk\chipmunk.h">
@@ -52,46 +46,49 @@
     <ClInclude Include="..\..\..\include\chipmunk\cpVect.h">
       <Filter>include</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\include\chipmunk\constraints\cpConstraint.h">
-      <Filter>include\constraints</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\include\chipmunk\constraints\cpDampedRotarySpring.h">
-      <Filter>include\constraints</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\include\chipmunk\constraints\cpDampedSpring.h">
-      <Filter>include\constraints</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\include\chipmunk\constraints\cpGearJoint.h">
-      <Filter>include\constraints</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\include\chipmunk\constraints\cpGrooveJoint.h">
-      <Filter>include\constraints</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\include\chipmunk\constraints\cpPinJoint.h">
-      <Filter>include\constraints</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\include\chipmunk\constraints\cpPivotJoint.h">
-      <Filter>include\constraints</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\include\chipmunk\constraints\cpRatchetJoint.h">
-      <Filter>include\constraints</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\include\chipmunk\constraints\cpRotaryLimitJoint.h">
-      <Filter>include\constraints</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\include\chipmunk\constraints\cpSimpleMotor.h">
-      <Filter>include\constraints</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\include\chipmunk\constraints\cpSlideJoint.h">
-      <Filter>include\constraints</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\include\chipmunk\constraints\util.h">
-      <Filter>include\constraints</Filter>
-    </ClInclude>
     <ClInclude Include="..\..\..\src\prime.h">
       <Filter>src</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\include\chipmunk\cpSpatialIndex.h">
+      <Filter>include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\include\chipmunk\chipmunk_private.h">
+      <Filter>include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\include\chipmunk\cpConstraint.h">
+      <Filter>include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\include\chipmunk\cpDampedRotarySpring.h">
+      <Filter>include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\include\chipmunk\cpDampedSpring.h">
+      <Filter>include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\include\chipmunk\cpGearJoint.h">
+      <Filter>include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\include\chipmunk\cpGrooveJoint.h">
+      <Filter>include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\include\chipmunk\cpPinJoint.h">
+      <Filter>include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\include\chipmunk\cpPivotJoint.h">
+      <Filter>include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\include\chipmunk\cpRatchetJoint.h">
+      <Filter>include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\include\chipmunk\cpRotaryLimitJoint.h">
+      <Filter>include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\include\chipmunk\cpSimpleMotor.h">
+      <Filter>include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\include\chipmunk\cpSlideJoint.h">
+      <Filter>include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\include\chipmunk\cpTransform.h">
       <Filter>include</Filter>
     </ClInclude>
   </ItemGroup>
@@ -103,9 +100,6 @@
       <Filter>src</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\src\cpArray.c">
-      <Filter>src</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\src\cpBB.c">
       <Filter>src</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\src\cpBody.c">
@@ -129,42 +123,6 @@
     <ClCompile Include="..\..\..\src\cpSpaceHash.c">
       <Filter>src</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\src\cpVect.c">
-      <Filter>src</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\src\constraints\cpConstraint.c">
-      <Filter>src\constraints</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\src\constraints\cpDampedRotarySpring.c">
-      <Filter>src\constraints</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\src\constraints\cpDampedSpring.c">
-      <Filter>src\constraints</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\src\constraints\cpGearJoint.c">
-      <Filter>src\constraints</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\src\constraints\cpGrooveJoint.c">
-      <Filter>src\constraints</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\src\constraints\cpPinJoint.c">
-      <Filter>src\constraints</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\src\constraints\cpPivotJoint.c">
-      <Filter>src\constraints</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\src\constraints\cpRatchetJoint.c">
-      <Filter>src\constraints</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\src\constraints\cpRotaryLimitJoint.c">
-      <Filter>src\constraints</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\src\constraints\cpSimpleMotor.c">
-      <Filter>src\constraints</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\src\constraints\cpSlideJoint.c">
-      <Filter>src\constraints</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\..\src\cpSpaceComponent.c">
       <Filter>src</Filter>
     </ClCompile>
@@ -181,6 +139,42 @@
       <Filter>src</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\src\cpSweep1D.c">
+      <Filter>src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\src\cpConstraint.c">
+      <Filter>src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\src\cpDampedRotarySpring.c">
+      <Filter>src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\src\cpDampedSpring.c">
+      <Filter>src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\src\cpGearJoint.c">
+      <Filter>src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\src\cpGrooveJoint.c">
+      <Filter>src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\src\cpPinJoint.c">
+      <Filter>src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\src\cpPivotJoint.c">
+      <Filter>src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\src\cpRatchetJoint.c">
+      <Filter>src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\src\cpRotaryLimitJoint.c">
+      <Filter>src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\src\cpSimpleMotor.c">
+      <Filter>src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\src\cpSlideJoint.c">
+      <Filter>src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\src\cpSpaceDebug.c">
       <Filter>src</Filter>
     </ClCompile>
   </ItemGroup>

--- a/msvc/vc12/demo/demo.vcxproj
+++ b/msvc/vc12/demo/demo.vcxproj
@@ -98,10 +98,12 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\..\include\chipmunk;..\..\glew\include;..\..\glfw\include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\include;..\..\glew\include;..\..\glfw\include</AdditionalIncludeDirectories>
       <CompileAs>CompileAsCpp</CompileAs>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <MinimalRebuild>false</MinimalRebuild>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -115,9 +117,11 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_USE_MATH_DEFINES;WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\..\include\chipmunk;..\..\glew\include;..\..\glfw\include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\include;..\..\glew\include;..\..\glfw\include</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <CompileAs>CompileAsCpp</CompileAs>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <MinimalRebuild>false</MinimalRebuild>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -130,8 +134,10 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_USE_MATH_DEFINES;WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\..\include\chipmunk;..\..\glew\include;..\..\glfw\include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\include;..\..\glew\include;..\..\glfw\include</AdditionalIncludeDirectories>
       <CompileAs>CompileAsCpp</CompileAs>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <MinimalRebuild>false</MinimalRebuild>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -145,8 +151,9 @@
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\..\include\chipmunk;..\..\glew\include;..\..\glfw\include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\include;..\..\glew\include;..\..\glfw\include</AdditionalIncludeDirectories>
       <CompileAs>CompileAsCpp</CompileAs>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -164,9 +171,10 @@
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_USE_MATH_DEFINES;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\..\include\chipmunk;..\..\glew\include;..\..\glfw\include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\include;..\..\glew\include;..\..\glfw\include</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <CompileAs>CompileAsCpp</CompileAs>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -183,8 +191,9 @@
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_USE_MATH_DEFINES;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\..\include\chipmunk;..\..\glew\include;..\..\glfw\include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\include;..\..\glew\include;..\..\glfw\include</AdditionalIncludeDirectories>
       <CompileAs>CompileAsCpp</CompileAs>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/msvc/vc13/chipmunk/chipmunk.vcxproj
+++ b/msvc/vc13/chipmunk/chipmunk.vcxproj
@@ -101,30 +101,30 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug SCRT|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v110</PlatformToolset>
+    <PlatformToolset>v120</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug DLL|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v110</PlatformToolset>
+    <PlatformToolset>v120</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v110</PlatformToolset>
+    <PlatformToolset>v120</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release SCRT|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v110</PlatformToolset>
+    <PlatformToolset>v120</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release DLL|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v110</PlatformToolset>
+    <PlatformToolset>v120</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -177,8 +177,10 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\..\include;..\..\..\include\chipmunk</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\include;</AdditionalIncludeDirectories>
       <CompileAs>CompileAsCpp</CompileAs>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <MinimalRebuild>false</MinimalRebuild>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -190,9 +192,11 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\..\include\chipmunk</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\include</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <CompileAs>CompileAsCpp</CompileAs>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <MinimalRebuild>false</MinimalRebuild>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -204,8 +208,10 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\..\include\chipmunk</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\include</AdditionalIncludeDirectories>
       <CompileAs>CompileAsCpp</CompileAs>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <MinimalRebuild>false</MinimalRebuild>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -219,8 +225,9 @@
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\..\include\chipmunk</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\include</AdditionalIncludeDirectories>
       <CompileAs>CompileAsCpp</CompileAs>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -235,9 +242,10 @@
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\..\include\chipmunk</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\include</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <CompileAs>CompileAsCpp</CompileAs>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -252,8 +260,9 @@
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\..\include\chipmunk</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\include</AdditionalIncludeDirectories>
       <CompileAs>CompileAsCpp</CompileAs>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/msvc/vc13/demo/demo.vcxproj
+++ b/msvc/vc13/demo/demo.vcxproj
@@ -38,26 +38,26 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug SCRT|Win32'" Label="Configuration">
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v110</PlatformToolset>
+    <PlatformToolset>v120</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug DLL|Win32'" Label="Configuration">
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v110</PlatformToolset>
+    <PlatformToolset>v120</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v110</PlatformToolset>
+    <PlatformToolset>v120</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release SCRT|Win32'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v110</PlatformToolset>
+    <PlatformToolset>v120</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release DLL|Win32'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v110</PlatformToolset>
+    <PlatformToolset>v120</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -98,10 +98,12 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\..\include\chipmunk;..\..\glew\include;..\..\glfw\include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\include;..\..\glew\include;..\..\glfw\include</AdditionalIncludeDirectories>
       <CompileAs>CompileAsCpp</CompileAs>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <MinimalRebuild>false</MinimalRebuild>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -115,9 +117,11 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_USE_MATH_DEFINES;WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\..\include\chipmunk;..\..\glew\include;..\..\glfw\include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\include;..\..\glew\include;..\..\glfw\include</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <CompileAs>CompileAsCpp</CompileAs>
+      <MinimalRebuild>false</MinimalRebuild>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -130,8 +134,10 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_USE_MATH_DEFINES;WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\..\include\chipmunk;..\..\glew\include;..\..\glfw\include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\include;..\..\glew\include;..\..\glfw\include</AdditionalIncludeDirectories>
       <CompileAs>CompileAsCpp</CompileAs>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <MinimalRebuild>false</MinimalRebuild>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -145,8 +151,9 @@
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\..\include\chipmunk;..\..\glew\include;..\..\glfw\include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\include;..\..\glew\include;..\..\glfw\include</AdditionalIncludeDirectories>
       <CompileAs>CompileAsCpp</CompileAs>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -164,9 +171,10 @@
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_USE_MATH_DEFINES;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\..\include\chipmunk;..\..\glew\include;..\..\glfw\include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\include;..\..\glew\include;..\..\glfw\include</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <CompileAs>CompileAsCpp</CompileAs>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -183,8 +191,9 @@
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_USE_MATH_DEFINES;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\..\include\chipmunk;..\..\glew\include;..\..\glfw\include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\include;..\..\glew\include;..\..\glfw\include</AdditionalIncludeDirectories>
       <CompileAs>CompileAsCpp</CompileAs>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>


### PR DESCRIPTION
These fixes are only for VS2012 and VS2013. Most build configurations are still broken.
- Fixed broken file paths and removed missing files for VS2012
  - Filters should now match between 2012 and 2013
- Fixed incorrect chipmunk include path for VS2012 and VS2013
- Projects now enable Multicore Processing for faster builds
  - Had to disable Minimal Rebuild, but from personal experience, that feature didn't really save much on build time.
- VS2013 projects now build with the VS2013 compiler
