### PR TITLE
Send cpMessage to android log, so that it will not get lost.

### DIFF
--- a/src/chipmunk.c
+++ b/src/chipmunk.c
@@ -22,6 +22,9 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdarg.h>
+#if defined(ANDROID)
+#	include <android/log.h>
+#endif
 
 #include "chipmunk/chipmunk_private.h"
 
@@ -32,12 +35,22 @@ cpMessage(const char *condition, const char *file, int line, int isError, int is
 	
 	va_list vargs;
 	va_start(vargs, message); {
+#if defined(ANDROID)
+		__android_log_print( ANDROID_LOG_INFO, "Chipmunk", "%s(%d)", file, line );
+		__android_log_print( ANDROID_LOG_INFO, "Chipmunk", message, vargs );
+#else
 		vfprintf(stderr, message, vargs);
 		fprintf(stderr, "\n");
+#endif
 	} va_end(vargs);
 	
+#if defined(ANDROID)
+	__android_log_print(ANDROID_LOG_INFO, "Chipmunk", "\tFailed condition: %s\n", condition);
+	__android_log_print(ANDROID_LOG_INFO, "Chipmunk", "\tSource:%s:%d\n", file, line);
+#else
 	fprintf(stderr, "\tFailed condition: %s\n", condition);
 	fprintf(stderr, "\tSource:%s:%d\n", file, line);
+#endif
 }
 
 #define STR(s) #s


### PR DESCRIPTION
On Android apps, all writes to stdout/stderr get lost.
This patch routes cpMessages to the device log.