### PR TITLE
Check for an Apple system when defining Mac specific policies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 2.6)
 cmake_policy(SET CMP0001 NEW) # don't use MAKE_BACKWARDS_COMPATIBILITY but policies instead
-cmake_policy(SET CMP0042 NEW) # use MACOSX_RPATH
+# CMP0042 is an apple specific option
+if (${APPLE})
+  cmake_policy(SET CMP0042 NEW) # use MACOSX_RPATH
+endif ()
 
 project(chipmunk)
 


### PR DESCRIPTION
It's the only thing standing in the way of an EC2 instance build