### PR TITLE
Correct the spelling of Xcode in README

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -38,9 +38,9 @@ Howling Moon Software (my company) is available for contracting if you want to m
 
 h2. BUILDING:
 
-Mac OS X: There is an included XCode project file for building the static library and demo application. Alternatively you could use the CMake files or the macstatic.command script inside the xcode/ directory to build a static lib and package up the headers for you.
+Mac OS X: There is an included Xcode project file for building the static library and demo application. Alternatively you could use the CMake files or the macstatic.command script inside the xcode/ directory to build a static lib and package up the headers for you.
 
-iPhone: A native Objective-C API is included. The XCode project can build a static library with all the proper compiler settings. Alternatively, you can just run iphonestatic.command in the xcode/ directory.  It will build you a fat library compiled as release for the device and debug for the simulator. After running it, you can simply drop the Chipmunk-iOS directory into your iPhone project!
+iPhone: A native Objective-C API is included. The Xcode project can build a static library with all the proper compiler settings. Alternatively, you can just run iphonestatic.command in the xcode/ directory.  It will build you a fat library compiled as release for the device and debug for the simulator. After running it, you can simply drop the Chipmunk-iOS directory into your iPhone project!
 
 UNIXes: A forum user was kind enough to make a set of CMake files for Chipmunk. This will require you to have CMake installed. To build run 'cmake .' then 'make'. This should build a dynamic library, a static library, and the demo application. A number of people have had build errors on Ubuntu due to not having GLUT or libxmu installed.
 


### PR DESCRIPTION

This pull request corrects the spelling of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
