### PR TITLE
Update ChipmunkSpace.h

### DIFF
--- a/objectivec/include/ObjectiveChipmunk/ChipmunkSpace.h
+++ b/objectivec/include/ObjectiveChipmunk/ChipmunkSpace.h
@@ -103,7 +103,7 @@
 /**
 	Returns true if the space is currently executing a timestep.
 */
-@property(nonatomic, readonly) BOOL locked;
+@property(nonatomic, readonly) BOOL isLocked;
 
 /**
 	An object that this space is associated with. You can use this get a reference to your game state or controller object from within callbacks.


### PR DESCRIPTION
ChipmunkSpace has the readonly property "locked", but in the implementation, the iVar _locked is never set. On the other hand, the implementation has an "isLocked" method (which actually checks the locking state of the associated chipmunk space).
So, I think the readonly property on the header file should also be called "isLocked".

I realised the issue because the ChipmunkBody.space.locked was returning NO, but I was still getting a cpAssertSpaceUnlocked inside cpBody.