### PR TITLE
demo: link with pthread on non MSVC builds

### DIFF
--- a/demo/CMakeLists.txt
+++ b/demo/CMakeLists.txt
@@ -37,7 +37,7 @@ if(APPLE)
 endif(APPLE)
 
 if(NOT MSVC)
-  list(APPEND chipmunk_demos_libraries m)
+  list(APPEND chipmunk_demos_libraries m pthread)
 endif(NOT MSVC)
 
 if(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")


### PR DESCRIPTION
With this patch we can apply following:

``` diff
diff --git a/demo/Bench.c b/demo/Bench.c
index ecd5ca6..66c42f4 100644
--- a/demo/Bench.c
+++ b/demo/Bench.c
@@ -2,7 +2,7 @@
 #include "chipmunk/chipmunk_unsafe.h"
 #include "ChipmunkDemo.h"

-#define ENABLE_HASTY 0
+#define ENABLE_HASTY 1
 #if ENABLE_HASTY
        #include "chipmunk/cpHastySpace.h"
```

and use HastySpace for on unix builds.
