### PR TITLE
Add space to macro usage so they are recognized as new macro calls in newer compilers

### DIFF
--- a/src/chipmunk.c
+++ b/src/chipmunk.c
@@ -56,7 +56,7 @@ cpMessage(const char *condition, const char *file, int line, int isError, int is
 #define STR(s) #s
 #define XSTR(s) STR(s)
 
-const char *cpVersionString = XSTR(CP_VERSION_MAJOR)"."XSTR(CP_VERSION_MINOR)"."XSTR(CP_VERSION_RELEASE);
+const char *cpVersionString = XSTR(CP_VERSION_MAJOR)"." XSTR(CP_VERSION_MINOR)"." XSTR(CP_VERSION_RELEASE);
 
 //MARK: Misc Functions
 


### PR DESCRIPTION
Adds a space to string usage in macros which seems to break newer VS compiler. Fixes #146 