### PR TITLE
Fix warnings when CP_DATA_POINTER_TYPE is defined.

### DIFF
--- a/src/cpSpace.c
+++ b/src/cpSpace.c
@@ -63,27 +63,27 @@ handlerSetTrans(cpCollisionHandler *handler, void *unused)
 // Default collision functions.
 
 static cpBool
-DefaultBegin(cpArbiter *arb, cpSpace *space, void *data){
+DefaultBegin(cpArbiter *arb, cpSpace *space, cpDataPointer data){
 	cpBool retA = cpArbiterCallWildcardBeginA(arb, space);
 	cpBool retB = cpArbiterCallWildcardBeginB(arb, space);
 	return retA && retB;
 }
 
 static cpBool
-DefaultPreSolve(cpArbiter *arb, cpSpace *space, void *data){
+DefaultPreSolve(cpArbiter *arb, cpSpace *space, cpDataPointer data){
 	cpBool retA = cpArbiterCallWildcardPreSolveA(arb, space);
 	cpBool retB = cpArbiterCallWildcardPreSolveB(arb, space);
 	return retA && retB;
 }
 
 static void
-DefaultPostSolve(cpArbiter *arb, cpSpace *space, void *data){
+DefaultPostSolve(cpArbiter *arb, cpSpace *space, cpDataPointer data){
 	cpArbiterCallWildcardPostSolveA(arb, space);
 	cpArbiterCallWildcardPostSolveB(arb, space);
 }
 
 static void
-DefaultSeparate(cpArbiter *arb, cpSpace *space, void *data){
+DefaultSeparate(cpArbiter *arb, cpSpace *space, cpDataPointer data){
 	cpArbiterCallWildcardSeparateA(arb, space);
 	cpArbiterCallWildcardSeparateB(arb, space);
 }
@@ -94,8 +94,8 @@ static cpCollisionHandler cpCollisionHandlerDefault = {
 	DefaultBegin, DefaultPreSolve, DefaultPostSolve, DefaultSeparate, NULL
 };
 
-static cpBool AlwaysCollide(cpArbiter *arb, cpSpace *space, void *data){return cpTrue;}
-static void DoNothing(cpArbiter *arb, cpSpace *space, void *data){}
+static cpBool AlwaysCollide(cpArbiter *arb, cpSpace *space, cpDataPointer data){return cpTrue;}
+static void DoNothing(cpArbiter *arb, cpSpace *space, cpDataPointer data){}
 
 cpCollisionHandler cpCollisionHandlerDoNothing = {
 	CP_WILDCARD_COLLISION_TYPE, CP_WILDCARD_COLLISION_TYPE,


### PR DESCRIPTION
When CP_DATA_POINTER_TYPE is set to something else (const void * in my case), certain default functions will cause warnings because they are still using void * as their data type. This is a quick fix for this.