### PR TITLE
Use CGFloat as the float type if CP_USE_CGTYPES is set.

### DIFF
--- a/include/chipmunk/chipmunk_types.h
+++ b/include/chipmunk/chipmunk_types.h
@@ -64,7 +64,11 @@
 #if CP_USE_DOUBLES
 /// Chipmunk's floating point type.
 /// Can be reconfigured at compile time.
-	typedef double cpFloat;
+	#if CP_USE_CGTYPES
+		typedef CGFloat cpFloat;
+	#else
+		typedef double cpFloat;
+	#endif
 	#define cpfsqrt sqrt
 	#define cpfsin sin
 	#define cpfcos cos
@@ -77,7 +81,11 @@
 	#define cpfceil ceil
 	#define CPFLOAT_MIN DBL_MIN
 #else
-	typedef float cpFloat;
+	#if CP_USE_CGTYPES
+		typedef CGFloat cpFloat;
+	#else
+		typedef float cpFloat;
+	#endif
 	#define cpfsqrt sqrtf
 	#define cpfsin sinf
 	#define cpfcos cosf


### PR DESCRIPTION
When bridging this library into Swift, the stricter typing means that all the CGFloat values from UIKit have to be cast back and forth from cpFloat. With this change, cpFloat is typedefed CGFloat if CP_USE_CGTYPES is set, which means no casts are required. This should have no effect when used from C, as CGFloat should be either float or double depending on the same conditions as cpFloat uses.