### PR TITLE
Fix normal sign on contact reporting for circle/poly collisions

### DIFF
--- a/src/cpCollision.c
+++ b/src/cpCollision.c
@@ -674,7 +674,7 @@ CircleToPoly(const cpCircleShape *circle, const cpPolyShape *poly, struct cpColl
 	// If the closest points are nearer than the sum of the radii...
 	if(points.d <= circle->r + poly->r){
 		cpVect n = info->n = points.n;
-		cpCollisionInfoPushContact(info, cpvadd(points.a, cpvmult(n, circle->r)), cpvadd(points.b, cpvmult(n, poly->r)), 0);
+		cpCollisionInfoPushContact(info, cpvadd(points.a, cpvmult(n, circle->r)), cpvadd(points.b, cpvmult(n, -poly->r)), 0);
 	}
 }
 


### PR DESCRIPTION
This pull request fixes a hidden bug where contact points are computed for circle/polygon collisions. It is related to issue #160 where I described the contact points were generated far away from each other, and not correctly resembling the real contact points.