### PR TITLE
Fix issue #144 of division by zero when setting zero mass, zero moment.

### DIFF
--- a/src/cpBody.c
+++ b/src/cpBody.c
@@ -258,7 +258,7 @@ cpBodySetMass(cpBody *body, cpFloat mass)
 	
 	cpBodyActivate(body);
 	body->m = mass;
-	body->m_inv = 1.0f/mass;
+	body->m_inv = mass == 0.0f ? INFINITY : 1.0f/mass;
 	cpAssertSaneBody(body);
 }
 
@@ -275,7 +275,7 @@ cpBodySetMoment(cpBody *body, cpFloat moment)
 	
 	cpBodyActivate(body);
 	body->i = moment;
-	body->i_inv = 1.0f/moment;
+	body->i_inv = moment == 0.0f ? INFINITY : 1.0f/moment;
 	cpAssertSaneBody(body);
 }
 

--- a/src/cpShape.c
+++ b/src/cpShape.c
@@ -303,7 +303,8 @@ cpCircleShapePointQuery(cpCircleShape *circle, cpVect p, cpPointQueryInfo *info)
 	cpFloat r = circle->r;
 	
 	info->shape = (cpShape *)circle;
-	info->point = cpvadd(circle->tc, cpvmult(delta, r/d)); // TODO: div/0
+	cpFloat r_over_d = d > 0.0f ? r/d : r;
+	info->point = cpvadd(circle->tc, cpvmult(delta, r_over_d)); // TODO: div/0
 	info->distance = d - r;
 	
 	// Use up for the gradient if the distance is very small.


### PR DESCRIPTION
Explicitly sets inverse-mass and inverse-moment to INIFINITY instead of dividing by zero.
This way, FP exceptions are not fired, halting programs that enable them.