### PR TITLE
Fix build failure on musl

### DIFF
--- a/src/cpHastySpace.c
+++ b/src/cpHastySpace.c
@@ -8,7 +8,9 @@
 
 //#include <sys/param.h >
 #ifndef _WIN32
+#ifdef __APPLE__
 #include <sys/sysctl.h>
+#endif
 #include <pthread.h>
 #else
 #ifndef WIN32_LEAN_AND_MEAN


### PR DESCRIPTION
Build fails on:
/home/test/autobuild/run/instance-0/output/build/chipmunk-7.0.2/src/cpHastySpace.c:11:24: fatal error: sys/sysctl.h: No such file or directory

Indeed, sys/sysctl.h is not available on musl so include this header
only if __APPLE__ is defined as sysctlbyname is only used in this case.

Fixes:
 - http://autobuild.buildroot.org/results/e5be2f8eb9315a9054e1c8d854dec37cbb28eed7

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>