### PR TITLE
include 'sys/sysctl.h' only for apple devices

### DIFF
--- a/src/cpHastySpace.c
+++ b/src/cpHastySpace.c
@@ -7,8 +7,12 @@
 //TODO: Move all the thread stuff to another file
 
 //#include <sys/param.h >
-#ifndef _WIN32
+
+#ifdef __APPLE__
 #include <sys/sysctl.h>
+#endif
+
+#ifndef _WIN32
 #include <pthread.h>
 #else
 #ifndef WIN32_LEAN_AND_MEAN


### PR DESCRIPTION
Hi.
As far as I know only 'sysctlbyname' function is used from 'sys/sysctl.h' header. 
But also as I see, that call is wrapped by preprocessor macro (519:522 lines of original 'cpHastySpace.c' file) which makes that call unreachable for all systems except Apple.

So, then why not include this file ONLY in Apple systems?
Some linux distros do not have 'sys/sysctl.h' at all, and 'sysctl.h' from 'linux' directory in 'linux-headers' (kernel headers) do not have 'sysctlbyname' func anyway.
