### PR TITLE
Fix a potential divide by zero in ClosestT

### DIFF
--- a/src/cpCollision.c
+++ b/src/cpCollision.c
@@ -200,7 +200,8 @@ static inline cpFloat
 ClosestT(const cpVect a, const cpVect b)
 {
 	cpVect delta = cpvsub(b, a);
-	return -cpfclamp(cpvdot(delta, cpvadd(a, b))/cpvlengthsq(delta), -1.0f, 1.0f);
+	cpFloat d2 = cpvlengthsq(delta);
+	return d2 ? -cpfclamp(cpvdot(delta, cpvadd(a, b))/d2, -1.0f, 1.0f) : 0.0f;
 }
 
 // Basically the same as cpvlerp(), except t = [-1, 1]


### PR DESCRIPTION
When points a and b are equal, the length of the segment is zero and ClosestT produces an invalid floating point operation (0/0).