### PR TITLE
Remove unused function 'EdgeNew'

### DIFF
--- a/src/cpCollision.c
+++ b/src/cpCollision.c
@@ -158,13 +158,6 @@ struct Edge {
 	cpVect n;
 };
 
-static inline struct Edge
-EdgeNew(cpVect va, cpVect vb, cpHashValue ha, cpHashValue hb, cpFloat r)
-{
-	struct Edge edge = {{va, ha}, {vb, hb}, r, cpvnormalize(cpvperp(cpvsub(vb, va)))};
-	return edge;
-}
-
 static struct Edge
 SupportEdgeForPoly(const cpPolyShape *poly, const cpVect n)
 {


### PR DESCRIPTION
Fixes Clang's warning -Wunused-function


Note that it's intended to be on the 6.2.x branch, I can't upgrade to Chipmunk 7 due to #104.