### PR TITLE
Fixes bug in cpSpaceShapeQuery

### DIFF
--- a/src/cpSpaceQuery.c
+++ b/src/cpSpaceQuery.c
@@ -224,7 +224,7 @@ ShapeQuery(cpShape *a, cpShape *b, cpCollisionID id, struct ShapeQueryContext *c
 	cpContactPointSet set = cpShapesCollide(a, b);
 	if(set.count){
 		if(context->func) context->func(b, &set, context->data);
-		context->anyCollision = !(a->sensor || b->sensor);
+		context->anyCollision |= !(a->sensor || b->sensor);
 	}
 	
 	return id;


### PR DESCRIPTION
Fixes bug in `cpSpaceShapeQuery`. Previously, the `anyCollision` flag would sometimes get cleared erroneously after a collision had already been detected.