### PR TITLE
Fix 'unused parameter' warnings

### DIFF
--- a/src/chipmunk.c
+++ b/src/chipmunk.c
@@ -31,6 +31,8 @@
 void
 cpMessage(const char *condition, const char *file, int line, int isError, int isHardError, const char *message, ...)
 {
+	(void)isHardError;
+
 	fprintf(stderr, (isError ? "Aborting due to Chipmunk error: " : "Chipmunk warning: "));
 	
 	va_list vargs;
@@ -91,7 +93,8 @@ cpAreaForSegment(cpVect a, cpVect b, cpFloat r)
 cpFloat
 cpMomentForPoly(cpFloat m, int count, const cpVect *verts, cpVect offset, cpFloat r)
 {
-	// TODO account for radius.
+	(void)r; // TODO account for radius.
+
 	if(count == 2) return cpMomentForSegment(m, verts[0], verts[1], 0.0f);
 	
 	cpFloat sum1 = 0.0f;

--- a/src/cpBBTree.c
+++ b/src/cpBBTree.c
@@ -484,6 +484,8 @@ MarkSubtree(Node *subtree, MarkContext *context)
 static Node *
 LeafNew(cpBBTree *tree, void *obj, cpBB bb)
 {
+	(void)bb;
+
 	Node *node = NodeFromPool(tree);
 	node->obj = obj;
 	node->bb = GetBB(tree, obj);
@@ -516,7 +518,12 @@ LeafUpdate(Node *leaf, cpBBTree *tree)
 	}
 }
 
-static cpCollisionID VoidQueryFunc(void *obj1, void *obj2, cpCollisionID id, void *data){return id;}
+static cpCollisionID
+VoidQueryFunc(void *obj1, void *obj2, cpCollisionID id, void *data)
+{
+	(void)obj1, (void)obj2, (void)data;
+	return id;
+}
 
 static void
 LeafAddPairs(Node *leaf, cpBBTree *tree)

--- a/src/cpBody.c
+++ b/src/cpBody.c
@@ -89,7 +89,11 @@ cpBodyNewStatic()
 	return body;
 }
 
-void cpBodyDestroy(cpBody *body){}
+void
+cpBodyDestroy(cpBody *body)
+{
+	(void)body;
+}
 
 void
 cpBodyFree(cpBody *body)

--- a/src/cpCollision.c
+++ b/src/cpCollision.c
@@ -95,6 +95,7 @@ typedef struct SupportPoint (*SupportPointFunc)(const cpShape *shape, const cpVe
 static inline struct SupportPoint
 CircleSupportPoint(const cpCircleShape *circle, const cpVect n)
 {
+	(void)n;
 	return SupportPointNew(circle->tc, 0);
 }
 
@@ -681,6 +682,7 @@ CircleToPoly(const cpCircleShape *circle, const cpPolyShape *poly, struct cpColl
 static void
 CollisionError(const cpShape *circle, const cpShape *poly, struct cpCollisionInfo *info)
 {
+	(void)circle, (void)poly, (void)info;
 	cpAssertHard(cpFalse, "Internal Error: Shape types are not sorted.");
 }
 

--- a/src/cpConstraint.c
+++ b/src/cpConstraint.c
@@ -23,7 +23,7 @@
 
 // TODO: Comment me!
 
-void cpConstraintDestroy(cpConstraint *constraint){}
+void cpConstraintDestroy(cpConstraint *constraint){(void)constraint;}
 
 void
 cpConstraintFree(cpConstraint *constraint)

--- a/src/cpDampedRotarySpring.c
+++ b/src/cpDampedRotarySpring.c
@@ -47,11 +47,17 @@ preStep(cpDampedRotarySpring *spring, cpFloat dt)
 	b->w += j_spring*b->i_inv;
 }
 
-static void applyCachedImpulse(cpDampedRotarySpring *spring, cpFloat dt_coef){}
+static void
+applyCachedImpulse(cpDampedRotarySpring *spring, cpFloat dt_coef)
+{
+	(void)spring; (void)dt_coef;
+}
 
 static void
 applyImpulse(cpDampedRotarySpring *spring, cpFloat dt)
 {
+	(void)dt;
+
 	cpBody *a = spring->constraint.a;
 	cpBody *b = spring->constraint.b;
 	

--- a/src/cpDampedSpring.c
+++ b/src/cpDampedSpring.c
@@ -52,11 +52,17 @@ preStep(cpDampedSpring *spring, cpFloat dt)
 	apply_impulses(a, b, spring->r1, spring->r2, cpvmult(spring->n, j_spring));
 }
 
-static void applyCachedImpulse(cpDampedSpring *spring, cpFloat dt_coef){}
+static void
+applyCachedImpulse(cpDampedSpring *spring, cpFloat dt_coef)
+{
+	(void)spring, (void)dt_coef;
+}
 
 static void
 applyImpulse(cpDampedSpring *spring, cpFloat dt)
 {
+	(void)dt;
+
 	cpBody *a = spring->constraint.a;
 	cpBody *b = spring->constraint.b;
 	

--- a/src/cpHastySpace.c
+++ b/src/cpHastySpace.c
@@ -471,6 +471,8 @@ RunWorkers(cpHastySpace *hasty, cpHastySpaceWorkFunction func)
 static void
 Solver(cpSpace *space, unsigned long worker, unsigned long worker_count)
 {
+	(void)worker;
+
 	cpArray *constraints = space->constraints;
 	cpArray *arbiters = space->arbiters;
 	

--- a/src/cpPolyline.c
+++ b/src/cpPolyline.c
@@ -561,6 +561,8 @@ FindSteiner(int count, cpVect *verts, struct Notch notch)
 static struct Notch
 DeepestNotch(int count, cpVect *verts, int hullCount, cpVect *hullVerts, int first, cpFloat tol)
 {
+	(void)tol;
+
 	struct Notch notch = {};
 	int j = Next(first, count);
 	

--- a/src/cpSimpleMotor.c
+++ b/src/cpSimpleMotor.c
@@ -24,6 +24,8 @@
 static void
 preStep(cpSimpleMotor *joint, cpFloat dt)
 {
+	(void)dt;
+
 	cpBody *a = joint->constraint.a;
 	cpBody *b = joint->constraint.b;
 	

--- a/src/cpSpace.c
+++ b/src/cpSpace.c
@@ -52,6 +52,8 @@ handlerSetEql(cpCollisionHandler *check, cpCollisionHandler *pair)
 static void *
 handlerSetTrans(cpCollisionHandler *handler, void *unused)
 {
+	(void)unused;
+
 	cpCollisionHandler *copy = (cpCollisionHandler *)cpcalloc(1, sizeof(cpCollisionHandler));
 	memcpy(copy, handler, sizeof(cpCollisionHandler));
 	
@@ -64,6 +66,7 @@ handlerSetTrans(cpCollisionHandler *handler, void *unused)
 
 static cpBool
 DefaultBegin(cpArbiter *arb, cpSpace *space, cpDataPointer data){
+	(void)data;
 	cpBool retA = cpArbiterCallWildcardBeginA(arb, space);
 	cpBool retB = cpArbiterCallWildcardBeginB(arb, space);
 	return retA && retB;
@@ -71,6 +74,7 @@ DefaultBegin(cpArbiter *arb, cpSpace *space, cpDataPointer data){
 
 static cpBool
 DefaultPreSolve(cpArbiter *arb, cpSpace *space, cpDataPointer data){
+	(void)data;
 	cpBool retA = cpArbiterCallWildcardPreSolveA(arb, space);
 	cpBool retB = cpArbiterCallWildcardPreSolveB(arb, space);
 	return retA && retB;
@@ -78,12 +82,14 @@ DefaultPreSolve(cpArbiter *arb, cpSpace *space, cpDataPointer data){
 
 static void
 DefaultPostSolve(cpArbiter *arb, cpSpace *space, cpDataPointer data){
+	(void)data;
 	cpArbiterCallWildcardPostSolveA(arb, space);
 	cpArbiterCallWildcardPostSolveB(arb, space);
 }
 
 static void
 DefaultSeparate(cpArbiter *arb, cpSpace *space, cpDataPointer data){
+	(void)data;
 	cpArbiterCallWildcardSeparateA(arb, space);
 	cpArbiterCallWildcardSeparateB(arb, space);
 }
@@ -94,8 +100,16 @@ static cpCollisionHandler cpCollisionHandlerDefault = {
 	DefaultBegin, DefaultPreSolve, DefaultPostSolve, DefaultSeparate, NULL
 };
 
-static cpBool AlwaysCollide(cpArbiter *arb, cpSpace *space, cpDataPointer data){return cpTrue;}
-static void DoNothing(cpArbiter *arb, cpSpace *space, cpDataPointer data){}
+static cpBool
+AlwaysCollide(cpArbiter *arb, cpSpace *space, cpDataPointer data){
+	(void)arb, (void)space, (void)data;
+	return cpTrue;
+}
+
+static void
+DoNothing(cpArbiter *arb, cpSpace *space, cpDataPointer data){
+	(void)arb, (void)space, (void)data;
+}
 
 cpCollisionHandler cpCollisionHandlerDoNothing = {
 	CP_WILDCARD_COLLISION_TYPE, CP_WILDCARD_COLLISION_TYPE,
@@ -106,7 +120,7 @@ cpCollisionHandler cpCollisionHandlerDoNothing = {
 static cpVect ShapeVelocityFunc(cpShape *shape){return shape->body->v;}
 
 // Used for disposing of collision handlers.
-static void FreeWrap(void *ptr, void *unused){cpfree(ptr);}
+static void FreeWrap(void *ptr, void *unused){(void)unused; cpfree(ptr);}
 
 //MARK: Memory Management Functions
 
@@ -183,7 +197,7 @@ cpSpaceNew(void)
 	return cpSpaceInit(cpSpaceAlloc());
 }
 
-static void cpBodyActivateWrap(cpBody *body, void *unused){cpBodyActivate(body);}
+static void cpBodyActivateWrap(cpBody *body, void *unused){(void)unused; cpBodyActivate(body);}
 
 void
 cpSpaceDestroy(cpSpace *space)

--- a/src/cpSpaceStep.c
+++ b/src/cpSpaceStep.c
@@ -35,7 +35,11 @@ cpSpaceGetPostStepCallback(cpSpace *space, void *key)
 	return NULL;
 }
 
-static void PostStepDoNothing(cpSpace *space, void *obj, void *data){}
+static void
+PostStepDoNothing(cpSpace *space, void *obj, void *data)
+{
+	(void)space, (void)obj, (void)data;
+}
 
 cpBool
 cpSpaceAddPostStepCallback(cpSpace *space, cpPostStepFunc func, void *key, void *data)
@@ -329,6 +333,7 @@ cpSpaceArbiterSetFilter(cpArbiter *arb, cpSpace *space)
  void
 cpShapeUpdateFunc(cpShape *shape, void *unused)
 {
+	(void)unused;
 	cpShapeCacheBB(shape);
 }
 

--- a/src/cpSweep1D.c
+++ b/src/cpSweep1D.c
@@ -52,6 +52,7 @@ BoundsOverlap(Bounds a, Bounds b)
 static inline Bounds
 BBToBounds(cpSweep1D *sweep, cpBB bb)
 {
+	(void)sweep;
 	Bounds bounds = {bb.l, bb.r};
 	return bounds;
 }
@@ -120,6 +121,8 @@ cpSweep1DEach(cpSweep1D *sweep, cpSpatialIndexIteratorFunc func, void *data)
 static int
 cpSweep1DContains(cpSweep1D *sweep, void *obj, cpHashValue hashid)
 {
+	(void)hashid;
+
 	TableCell *table = sweep->table;
 	for(int i=0, count=sweep->num; i<count; i++){
 		if(table[i].obj == obj) return cpTrue;
@@ -133,6 +136,8 @@ cpSweep1DContains(cpSweep1D *sweep, void *obj, cpHashValue hashid)
 static void
 cpSweep1DInsert(cpSweep1D *sweep, void *obj, cpHashValue hashid)
 {
+	(void)hashid;
+
 	if(sweep->num == sweep->max) ResizeTable(sweep, sweep->max*2);
 	
 	sweep->table[sweep->num] = MakeTableCell(sweep, obj);
@@ -142,6 +147,8 @@ cpSweep1DInsert(cpSweep1D *sweep, void *obj, cpHashValue hashid)
 static void
 cpSweep1DRemove(cpSweep1D *sweep, void *obj, cpHashValue hashid)
 {
+	(void)hashid;
+
 	TableCell *table = sweep->table;
 	for(int i=0, count=sweep->num; i<count; i++){
 		if(table[i].obj == obj){
@@ -160,12 +167,14 @@ cpSweep1DRemove(cpSweep1D *sweep, void *obj, cpHashValue hashid)
 static void
 cpSweep1DReindexObject(cpSweep1D *sweep, void *obj, cpHashValue hashid)
 {
+	(void)sweep, (void)obj, (void)hashid;
 	// Nothing to do here
 }
 
 static void
 cpSweep1DReindex(cpSweep1D *sweep)
 {
+	(void)sweep;
 	// Nothing to do here
 	// Could perform a sort, but queries are not accelerated anyway.
 }
@@ -190,6 +199,8 @@ cpSweep1DQuery(cpSweep1D *sweep, void *obj, cpBB bb, cpSpatialIndexQueryFunc fun
 static void
 cpSweep1DSegmentQuery(cpSweep1D *sweep, void *obj, cpVect a, cpVect b, cpFloat t_exit, cpSpatialIndexSegmentQueryFunc func, void *data)
 {
+	(void)t_exit;
+
 	cpBB bb = cpBBExpand(cpBBNew(a.x, a.y, a.x, a.y), b);
 	Bounds bounds = BBToBounds(sweep, bb);
 	


### PR DESCRIPTION
When compiling with -Wall -Wextra, I get about 20 `unused parameter` warnings.
I'm not sure if these were voluntarily left there or not, but I silenced them.