### PR TITLE
docs: fix simple typo, straigt -> straight

### DIFF
--- a/include/chipmunk/cpPolyline.h
+++ b/include/chipmunk/cpPolyline.h
@@ -23,7 +23,7 @@ CP_EXPORT cpPolyline *cpPolylineSimplifyCurves(cpPolyline *line, cpFloat tol);
 
 /**
 	Returns a copy of a polyline simplified by discarding "flat" vertexes.
-	This works well on straigt edged or angular shapes, not as well on smooth shapes.
+	This works well on straight edged or angular shapes, not as well on smooth shapes.
 */
 CP_EXPORT cpPolyline *cpPolylineSimplifyVertexes(cpPolyline *line, cpFloat tol);
 

--- a/objectivec/include/ObjectiveChipmunk/ChipmunkAutoGeometry.h
+++ b/objectivec/include/ObjectiveChipmunk/ChipmunkAutoGeometry.h
@@ -47,7 +47,7 @@
 
 /**
 	Returns a copy of a polyline simplified by discarding "flat" vertexes.
-	This works well on straigt edged or angular shapes, not as well on smooth shapes.
+	This works well on straight edged or angular shapes, not as well on smooth shapes.
 */
 -(ChipmunkPolyline *)simplifyVertexes:(cpFloat)tolerance;
 


### PR DESCRIPTION
There is a small typo in include/chipmunk/cpPolyline.h, objectivec/include/ObjectiveChipmunk/ChipmunkAutoGeometry.h.

Should read `straight` rather than `straigt`.

