### PR TITLE
Fix condition is always true

### DIFF
--- a/include/chipmunk/chipmunk_structs.h
+++ b/include/chipmunk/chipmunk_structs.h
@@ -428,7 +428,7 @@ struct cpSpace {
 	cpArray *pooledArbiters;
 	
 	cpArray *allocatedBuffers;
-	unsigned int locked;
+	int locked;
 	
 	cpBool usesWildcards;
 	cpHashSet *collisionHandlers;


### PR DESCRIPTION
This assert checks for `>= 0` for an unsigned number which is always true, shouldn't the number be signed?

https://github.com/slembcke/Chipmunk2D/blob/edf83e5603c5a0a104996bd816fca6d3facedd6a/src/cpSpaceStep.c#L71-L72

https://github.com/slembcke/Chipmunk2D/blob/edf83e5603c5a0a104996bd816fca6d3facedd6a/include/chipmunk/chipmunk_structs.h#L431

gcc warning:
```
Chipmunk2D/src/cpSpaceStep.c:72:29: warning: comparison of unsigned expression in ‘>= 0’ is always true [-Wtype-limits]
   72 |  cpAssertHard(space->locked >= 0, "Internal Error: Space lock underflow.");
```