### PR TITLE
Remove duplicate assignments in cpSpaceDebug

### DIFF
--- a/src/cpSpaceDebug.c
+++ b/src/cpSpaceDebug.c
@@ -123,8 +123,6 @@ cpSpaceDebugDrawConstraint(cpConstraint *constraint, cpSpaceDebugDrawOptions *op
 		options->drawSegment(a, b, color, data);
 	} else if(cpConstraintIsDampedSpring(constraint)){
 		cpDampedSpring *spring = (cpDampedSpring *)constraint;
-		cpDataPointer data = options->data;
-		cpSpaceDebugColor color = options->constraintColor;
 		
 		cpVect a = cpTransformPoint(body_a->transform, spring->anchorA);
 		cpVect b = cpTransformPoint(body_b->transform, spring->anchorB);


### PR DESCRIPTION
data and color variables are already declared at the top of the function, at line 83-84

https://github.com/slembcke/Chipmunk2D/blob/a3cae1fc050a991a08dd1aa657a7259956a13799/src/cpSpaceDebug.c#L83-L84

duplicated at line 126-127

https://github.com/slembcke/Chipmunk2D/blob/edf83e5603c5a0a104996bd816fca6d3facedd6a/src/cpSpaceDebug.c#L126-L127