### PR TITLE
Visual Studio 2019 cannot compile demo in C++ mode

### DIFF
--- a/demo/CMakeLists.txt
+++ b/demo/CMakeLists.txt
@@ -43,12 +43,6 @@ link_directories(${chipmunk_demos_library_dirs})
 add_executable(chipmunk_demos ${chipmunk_demos_source_files})
 target_link_libraries(chipmunk_demos ${chipmunk_demos_libraries})
 
-# Tell MSVC to compile the code as C++.
-if(MSVC)
-	set_source_files_properties(${chipmunk_demos_source_files} PROPERTIES LANGUAGE CXX)
-	set_target_properties(chipmunk_demos PROPERTIES LINKER_LANGUAGE CXX)
-endif(MSVC)
-
 if(INSTALL_DEMOS)
 	install(TARGETS chipmunk_demos RUNTIME DESTINATION bin)
 endif(INSTALL_DEMOS)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,11 +15,6 @@ if(BUILD_SHARED)
   add_library(chipmunk SHARED
     ${chipmunk_source_files}
   )
-  # Tell MSVC to compile the code as C++.
-  if(MSVC)
-    set_source_files_properties(${chipmunk_source_files} PROPERTIES LANGUAGE CXX)
-    set_target_properties(chipmunk PROPERTIES LINKER_LANGUAGE CXX)
-  endif(MSVC)
   # set the lib's version number
   # But avoid on Android because symlinks to version numbered .so's don't work with Android's Java-side loadLibrary.
   if(NOT ANDROID)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,7 +18,7 @@ if(BUILD_SHARED)
   # Tell MSVC to compile the code as C++.
   if(MSVC)
     set_source_files_properties(${chipmunk_source_files} PROPERTIES LANGUAGE CXX)
-    set_target_properties(chipmunk_static PROPERTIES LINKER_LANGUAGE CXX)
+    set_target_properties(chipmunk PROPERTIES LINKER_LANGUAGE CXX)
   endif(MSVC)
   # set the lib's version number
   # But avoid on Android because symlinks to version numbered .so's don't work with Android's Java-side loadLibrary.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,6 +15,11 @@ if(BUILD_SHARED)
   add_library(chipmunk SHARED
     ${chipmunk_source_files}
   )
+  # Tell MSVC to compile the code as C++.
+  if(MSVC)
+    set_source_files_properties(${chipmunk_source_files} PROPERTIES LANGUAGE CXX)
+    set_target_properties(chipmunk_static PROPERTIES LINKER_LANGUAGE CXX)
+  endif(MSVC)
   # set the lib's version number
   # But avoid on Android because symlinks to version numbered .so's don't work with Android's Java-side loadLibrary.
   if(NOT ANDROID)


### PR DESCRIPTION
Remove CXX mode specified in CMAKE files to make it compile for VS 2019 ( MSVC 14)