### PR TITLE
Added new transform property to cpSpaceDebugDrawOptions

### DIFF
--- a/include/chipmunk/cpSpace.h
+++ b/include/chipmunk/cpSpace.h
@@ -38,7 +38,8 @@ typedef void (*cpCollisionSeparateFunc)(cpArbiter *arb, cpSpace *space, cpDataPo
 
 /// Struct that holds function callback pointers to configure custom collision handling.
 /// Collision handlers have a pair of types; when a collision occurs between two shapes that have these types, the collision handler functions are triggered.
-struct cpCollisionHandler {
+struct cpCollisionHandler
+{
 	/// Collision type identifier of the first shape that this handler recognizes.
 	/// In the collision handler callback, the shape with this type will be the first argument. Read only.
 	const cpCollisionType typeA;
@@ -61,21 +62,19 @@ struct cpCollisionHandler {
 
 // TODO: Make timestep a parameter?
 
-
 //MARK: Memory and Initialization
 
 /// Allocate a cpSpace.
-CP_EXPORT cpSpace* cpSpaceAlloc(void);
+CP_EXPORT cpSpace *cpSpaceAlloc(void);
 /// Initialize a cpSpace.
-CP_EXPORT cpSpace* cpSpaceInit(cpSpace *space);
+CP_EXPORT cpSpace *cpSpaceInit(cpSpace *space);
 /// Allocate and initialize a cpSpace.
-CP_EXPORT cpSpace* cpSpaceNew(void);
+CP_EXPORT cpSpace *cpSpaceNew(void);
 
 /// Destroy a cpSpace.
 CP_EXPORT void cpSpaceDestroy(cpSpace *space);
 /// Destroy and free a cpSpace.
 CP_EXPORT void cpSpaceFree(cpSpace *space);
-
 
 //MARK: Properties
 
@@ -131,7 +130,7 @@ CP_EXPORT void cpSpaceSetUserData(cpSpace *space, cpDataPointer userData);
 
 /// The Space provided static body for a given cpSpace.
 /// This is merely provided for convenience and you are not required to use it.
-CP_EXPORT cpBody* cpSpaceGetStaticBody(const cpSpace *space);
+CP_EXPORT cpBody *cpSpaceGetStaticBody(const cpSpace *space);
 
 /// Returns the current (or most recent) time step used with the given space.
 /// Useful from callbacks if your time step is not a compile-time global.
@@ -139,7 +138,6 @@ CP_EXPORT cpFloat cpSpaceGetCurrentTimeStep(const cpSpace *space);
 
 /// returns true from inside a callback when objects cannot be added/removed.
 CP_EXPORT cpBool cpSpaceIsLocked(cpSpace *space);
-
 
 //MARK: Collision Handlers
 
@@ -151,16 +149,15 @@ CP_EXPORT cpCollisionHandler *cpSpaceAddCollisionHandler(cpSpace *space, cpColli
 /// Create or return the existing wildcard collision handler for the specified type.
 CP_EXPORT cpCollisionHandler *cpSpaceAddWildcardHandler(cpSpace *space, cpCollisionType type);
 
-
 //MARK: Add/Remove objects
 
 /// Add a collision shape to the simulation.
 /// If the shape is attached to a static body, it will be added as a static shape.
-CP_EXPORT cpShape* cpSpaceAddShape(cpSpace *space, cpShape *shape);
+CP_EXPORT cpShape *cpSpaceAddShape(cpSpace *space, cpShape *shape);
 /// Add a rigid body to the simulation.
-CP_EXPORT cpBody* cpSpaceAddBody(cpSpace *space, cpBody *body);
+CP_EXPORT cpBody *cpSpaceAddBody(cpSpace *space, cpBody *body);
 /// Add a constraint to the simulation.
-CP_EXPORT cpConstraint* cpSpaceAddConstraint(cpSpace *space, cpConstraint *constraint);
+CP_EXPORT cpConstraint *cpSpaceAddConstraint(cpSpace *space, cpConstraint *constraint);
 
 /// Remove a collision shape from the simulation.
 CP_EXPORT void cpSpaceRemoveShape(cpSpace *space, cpShape *shape);
@@ -185,7 +182,6 @@ typedef void (*cpPostStepFunc)(cpSpace *space, void *key, void *data);
 /// Returns true only if @c key has never been scheduled before.
 /// It's possible to pass @c NULL for @c func if you only want to mark @c key as being used.
 CP_EXPORT cpBool cpSpaceAddPostStepCallback(cpSpace *space, cpPostStepFunc func, void *key, void *data);
-
 
 //MARK: Queries
 
@@ -217,7 +213,6 @@ typedef void (*cpSpaceShapeQueryFunc)(cpShape *shape, cpContactPointSet *points,
 /// Query a space for any shapes overlapping the given shape and call @c func for each shape found.
 CP_EXPORT cpBool cpSpaceShapeQuery(cpSpace *space, cpShape *shape, cpSpaceShapeQueryFunc func, void *data);
 
-
 //MARK: Iteration
 
 /// Space/body iterator callback function type.
@@ -235,7 +230,6 @@ typedef void (*cpSpaceConstraintIteratorFunc)(cpConstraint *constraint, void *da
 /// Call @c func for each shape in the space.
 CP_EXPORT void cpSpaceEachConstraint(cpSpace *space, cpSpaceConstraintIteratorFunc func, void *data);
 
-
 //MARK: Indexing
 
 /// Update the collision detection info for the static shapes in the space.
@@ -248,19 +242,18 @@ CP_EXPORT void cpSpaceReindexShapesForBody(cpSpace *space, cpBody *body);
 /// Switch the space to use a spatial has as it's spatial index.
 CP_EXPORT void cpSpaceUseSpatialHash(cpSpace *space, cpFloat dim, int count);
 
-
 //MARK: Time Stepping
 
 /// Step the space forward in time by @c dt.
 CP_EXPORT void cpSpaceStep(cpSpace *space, cpFloat dt);
-
 
 //MARK: Debug API
 
 #ifndef CP_SPACE_DISABLE_DEBUG_API
 
 /// Color type to use with the space debug drawing API.
-typedef struct cpSpaceDebugColor {
+typedef struct cpSpaceDebugColor
+{
 	float r, g, b, a;
 } cpSpaceDebugColor;
 
@@ -277,14 +270,16 @@ typedef void (*cpSpaceDebugDrawDotImpl)(cpFloat size, cpVect pos, cpSpaceDebugCo
 /// Callback type for a function that returns a color for a given shape. This gives you an opportunity to color shapes based on how they are used in your engine.
 typedef cpSpaceDebugColor (*cpSpaceDebugDrawColorForShapeImpl)(cpShape *shape, cpDataPointer data);
 
-typedef enum cpSpaceDebugDrawFlags {
-	CP_SPACE_DEBUG_DRAW_SHAPES = 1<<0,
-	CP_SPACE_DEBUG_DRAW_CONSTRAINTS = 1<<1,
-	CP_SPACE_DEBUG_DRAW_COLLISION_POINTS = 1<<2,
+typedef enum cpSpaceDebugDrawFlags
+{
+	CP_SPACE_DEBUG_DRAW_SHAPES = 1 << 0,
+	CP_SPACE_DEBUG_DRAW_CONSTRAINTS = 1 << 1,
+	CP_SPACE_DEBUG_DRAW_COLLISION_POINTS = 1 << 2,
 } cpSpaceDebugDrawFlags;
 
 /// Struct used with cpSpaceDebugDraw() containing drawing callbacks and other drawing settings.
-typedef struct cpSpaceDebugDrawOptions {
+typedef struct cpSpaceDebugDrawOptions
+{
 	/// Function that will be invoked to draw circles.
 	cpSpaceDebugDrawCircleImpl drawCircle;
 	/// Function that will be invoked to draw line segments.
@@ -295,7 +290,7 @@ typedef struct cpSpaceDebugDrawOptions {
 	cpSpaceDebugDrawPolygonImpl drawPolygon;
 	/// Function that will be invoked to draw dots.
 	cpSpaceDebugDrawDotImpl drawDot;
-	
+
 	/// Flags that request which things to draw (collision shapes, constraints, contact points).
 	cpSpaceDebugDrawFlags flags;
 	/// Outline color passed to the drawing function.
@@ -306,7 +301,9 @@ typedef struct cpSpaceDebugDrawOptions {
 	cpSpaceDebugColor constraintColor;
 	/// Color passed to drawing functions for collision points.
 	cpSpaceDebugColor collisionPointColor;
-	
+	/// Transform used to transform the things to draw.
+	cpTransform transform;
+
 	/// User defined context pointer passed to all of the callback functions as the 'data' argument.
 	cpDataPointer data;
 } cpSpaceDebugDrawOptions;

--- a/src/cpSpaceDebug.c
+++ b/src/cpSpaceDebug.c
@@ -28,33 +28,68 @@ cpSpaceDebugDrawShape(cpShape *shape, cpSpaceDebugDrawOptions *options)
 {
 	cpBody *body = shape->body;
 	cpDataPointer data = options->data;
-	
+
 	cpSpaceDebugColor outline_color = options->shapeOutlineColor;
 	cpSpaceDebugColor fill_color = options->colorForShape(shape, data);
-	
-	switch(shape->klass->type){
-		case CP_CIRCLE_SHAPE: {
-			cpCircleShape *circle = (cpCircleShape *)shape;
-			options->drawCircle(circle->tc, body->a, circle->r, outline_color, fill_color, data);
-			break;
+
+	switch (shape->klass->type)
+	{
+	case CP_CIRCLE_SHAPE:
+	{
+		cpCircleShape *circle = (cpCircleShape *)shape;
+
+		cpVect tc = cpTransformPoint(options->transform, circle->tc);
+		cpVect tc2 = cpv(circle->tc.x + circle->r, circle->tc.y);
+		tc2 = cpTransformPoint(options->transform, tc2);
+		cpFloat r = cpvdist(tc, tc2);
+
+		cpVect pp0 = cpTransformPoint(options->transform, cpvzero);
+		cpVect pp1 = cpTransformPoint(options->transform, cpv(1, 0));
+		cpFloat dx = pp1.x - pp0.x;
+		cpFloat dy = pp1.y - pp0.y;
+		cpFloat angle = body->a + cpfatan2(dy, dx);
+
+		options->drawCircle(tc, angle, r, outline_color, fill_color, data);
+		break;
+	}
+	case CP_SEGMENT_SHAPE:
+	{
+		cpSegmentShape *seg = (cpSegmentShape *)shape;
+
+		cpVect ta = cpTransformPoint(options->transform, seg->ta);
+		cpVect tb = cpTransformPoint(options->transform, seg->tb);
+		cpVect ta2 = cpv(seg->ta.x + seg->r, seg->ta.y);
+		ta2 = cpTransformPoint(options->transform, ta2);
+		cpFloat r = cpvdist(ta, ta2);
+
+		options->drawFatSegment(ta, tb, r, outline_color, fill_color, data);
+		break;
+	}
+	case CP_POLY_SHAPE:
+	{
+		cpPolyShape *poly = (cpPolyShape *)shape;
+
+		int count = poly->count;
+		struct cpSplittingPlane *planes = poly->planes;
+		cpVect *verts = (cpVect *)alloca(count * sizeof(cpVect));
+		cpFloat r = poly->r;
+		for (int i = 0; i < count; i++)
+		{
+
+			verts[i] = cpTransformPoint(options->transform, planes[i].v0);
+			if (i == 0)
+			{
+				cpVect p = cpv(planes[0].v0.x + r, planes[0].v0.y);
+				cpVect v2 = cpTransformPoint(options->transform, p);
+				r = cpvdist(verts[0], v2);
+			}
 		}
-		case CP_SEGMENT_SHAPE: {
-			cpSegmentShape *seg = (cpSegmentShape *)shape;
-			options->drawFatSegment(seg->ta, seg->tb, seg->r, outline_color, fill_color, data);
-			break;
-		}
-		case CP_POLY_SHAPE: {
-			cpPolyShape *poly = (cpPolyShape *)shape;
-			
-			int count = poly->count;
-			struct cpSplittingPlane *planes = poly->planes;
-			cpVect *verts = (cpVect *)alloca(count*sizeof(cpVect));
-			
-			for(int i=0; i<count; i++) verts[i] = planes[i].v0;
-			options->drawPolygon(count, verts, poly->r, outline_color, fill_color, data);
-			break;
-		}
-		default: break;
+
+		options->drawPolygon(count, verts, r, outline_color, fill_color, data);
+		break;
+	}
+	default:
+		break;
 	}
 }
 
@@ -62,122 +97,159 @@ static const cpVect spring_verts[] = {
 	{0.00f, 0.0f},
 	{0.20f, 0.0f},
 	{0.25f, 3.0f},
-	{0.30f,-6.0f},
+	{0.30f, -6.0f},
 	{0.35f, 6.0f},
-	{0.40f,-6.0f},
+	{0.40f, -6.0f},
 	{0.45f, 6.0f},
-	{0.50f,-6.0f},
+	{0.50f, -6.0f},
 	{0.55f, 6.0f},
-	{0.60f,-6.0f},
+	{0.60f, -6.0f},
 	{0.65f, 6.0f},
-	{0.70f,-3.0f},
+	{0.70f, -3.0f},
 	{0.75f, 6.0f},
 	{0.80f, 0.0f},
 	{1.00f, 0.0f},
 };
-static const int spring_count = sizeof(spring_verts)/sizeof(cpVect);
+static const int spring_count = sizeof(spring_verts) / sizeof(cpVect);
 
 static void
 cpSpaceDebugDrawConstraint(cpConstraint *constraint, cpSpaceDebugDrawOptions *options)
 {
 	cpDataPointer data = options->data;
 	cpSpaceDebugColor color = options->constraintColor;
-	
+
 	cpBody *body_a = constraint->a;
 	cpBody *body_b = constraint->b;
 
-	if(cpConstraintIsPinJoint(constraint)){
+	// The size of dots are not scaled by the transform, to make it possible
+	// to use the transform to make drawing of a "small" (in pixels)
+	// simulation without the dots filling up the screen.
+	if (cpConstraintIsPinJoint(constraint))
+	{
 		cpPinJoint *joint = (cpPinJoint *)constraint;
-		
-		cpVect a = cpTransformPoint(body_a->transform, joint->anchorA);
-		cpVect b = cpTransformPoint(body_b->transform, joint->anchorB);
-		
-		options->drawDot(5, a, color, data);
-		options->drawDot(5, b, color, data);
-		options->drawSegment(a, b, color, data);
-	} else if(cpConstraintIsSlideJoint(constraint)){
-		cpSlideJoint *joint = (cpSlideJoint *)constraint;
-	
-		cpVect a = cpTransformPoint(body_a->transform, joint->anchorA);
-		cpVect b = cpTransformPoint(body_b->transform, joint->anchorB);
-		
-		options->drawDot(5, a, color, data);
-		options->drawDot(5, b, color, data);
-		options->drawSegment(a, b, color, data);
-	} else if(cpConstraintIsPivotJoint(constraint)){
-		cpPivotJoint *joint = (cpPivotJoint *)constraint;
-	
+
 		cpVect a = cpTransformPoint(body_a->transform, joint->anchorA);
 		cpVect b = cpTransformPoint(body_b->transform, joint->anchorB);
 
+		a = cpTransformPoint(options->transform, a);
+		b = cpTransformPoint(options->transform, b);
+
 		options->drawDot(5, a, color, data);
 		options->drawDot(5, b, color, data);
-	} else if(cpConstraintIsGrooveJoint(constraint)){
+		options->drawSegment(a, b, color, data);
+	}
+	else if (cpConstraintIsSlideJoint(constraint))
+	{
+		cpSlideJoint *joint = (cpSlideJoint *)constraint;
+
+		cpVect a = cpTransformPoint(body_a->transform, joint->anchorA);
+		cpVect b = cpTransformPoint(body_b->transform, joint->anchorB);
+
+		a = cpTransformPoint(options->transform, a);
+		b = cpTransformPoint(options->transform, b);
+
+		options->drawDot(5, a, color, data);
+		options->drawDot(5, b, color, data);
+		options->drawSegment(a, b, color, data);
+	}
+	else if (cpConstraintIsPivotJoint(constraint))
+	{
+		cpPivotJoint *joint = (cpPivotJoint *)constraint;
+
+		cpVect a = cpTransformPoint(body_a->transform, joint->anchorA);
+		cpVect b = cpTransformPoint(body_b->transform, joint->anchorB);
+
+		a = cpTransformPoint(options->transform, a);
+		b = cpTransformPoint(options->transform, b);
+
+		options->drawDot(5, a, color, data);
+		options->drawDot(5, b, color, data);
+	}
+	else if (cpConstraintIsGrooveJoint(constraint))
+	{
 		cpGrooveJoint *joint = (cpGrooveJoint *)constraint;
-	
+
 		cpVect a = cpTransformPoint(body_a->transform, joint->grv_a);
 		cpVect b = cpTransformPoint(body_a->transform, joint->grv_b);
 		cpVect c = cpTransformPoint(body_b->transform, joint->anchorB);
-		
+
+		a = cpTransformPoint(options->transform, a);
+		b = cpTransformPoint(options->transform, b);
+		c = cpTransformPoint(options->transform, c);
+
 		options->drawDot(5, c, color, data);
 		options->drawSegment(a, b, color, data);
-	} else if(cpConstraintIsDampedSpring(constraint)){
+	}
+	else if (cpConstraintIsDampedSpring(constraint))
+	{
 		cpDampedSpring *spring = (cpDampedSpring *)constraint;
-		
+
 		cpVect a = cpTransformPoint(body_a->transform, spring->anchorA);
 		cpVect b = cpTransformPoint(body_b->transform, spring->anchorB);
-		
+
+		a = cpTransformPoint(options->transform, a);
+		b = cpTransformPoint(options->transform, b);
+
 		options->drawDot(5, a, color, data);
 		options->drawDot(5, b, color, data);
 
 		cpVect delta = cpvsub(b, a);
 		cpFloat cos = delta.x;
 		cpFloat sin = delta.y;
-		cpFloat s = 1.0f/cpvlength(delta);
-		
-		cpVect r1 = cpv(cos, -sin*s);
-		cpVect r2 = cpv(sin,  cos*s);
-		
-		cpVect *verts = (cpVect *)alloca(spring_count*sizeof(cpVect));
-		for(int i=0; i<spring_count; i++){
+		cpFloat s = 1.0f / cpvlength(delta);
+
+		cpVect r1 = cpv(cos, -sin * s);
+		cpVect r2 = cpv(sin, cos * s);
+
+		cpVect *verts = (cpVect *)alloca(spring_count * sizeof(cpVect));
+		for (int i = 0; i < spring_count; i++)
+		{
 			cpVect v = spring_verts[i];
 			verts[i] = cpv(cpvdot(v, r1) + a.x, cpvdot(v, r2) + a.y);
 		}
-		
-		for(int i=0; i<spring_count-1; i++){
+
+		for (int i = 0; i < spring_count - 1; i++)
+		{
 			options->drawSegment(verts[i], verts[i + 1], color, data);
 		}
 	}
 }
 
-void
-cpSpaceDebugDraw(cpSpace *space, cpSpaceDebugDrawOptions *options)
+void cpSpaceDebugDraw(cpSpace *space, cpSpaceDebugDrawOptions *options)
 {
-	if(options->flags & CP_SPACE_DEBUG_DRAW_SHAPES){
+	if (options->flags & CP_SPACE_DEBUG_DRAW_SHAPES)
+	{
 		cpSpaceEachShape(space, (cpSpaceShapeIteratorFunc)cpSpaceDebugDrawShape, options);
 	}
-	
-	if(options->flags & CP_SPACE_DEBUG_DRAW_CONSTRAINTS){
+
+	if (options->flags & CP_SPACE_DEBUG_DRAW_CONSTRAINTS)
+	{
 		cpSpaceEachConstraint(space, (cpSpaceConstraintIteratorFunc)cpSpaceDebugDrawConstraint, options);
 	}
-	
-	if(options->flags & CP_SPACE_DEBUG_DRAW_COLLISION_POINTS){
+
+	if (options->flags & CP_SPACE_DEBUG_DRAW_COLLISION_POINTS)
+	{
 		cpArray *arbiters = space->arbiters;
 		cpSpaceDebugColor color = options->collisionPointColor;
 		cpSpaceDebugDrawSegmentImpl draw_seg = options->drawSegment;
 		cpDataPointer data = options->data;
-		
-		for(int i=0; i<arbiters->num; i++){
-			cpArbiter *arb = (cpArbiter*)arbiters->arr[i];
+
+		for (int i = 0; i < arbiters->num; i++)
+		{
+			cpArbiter *arb = (cpArbiter *)arbiters->arr[i];
 			cpVect n = arb->n;
-			
-			for(int j=0; j<arb->count; j++){
+
+			for (int j = 0; j < arb->count; j++)
+			{
 				cpVect p1 = cpvadd(arb->body_a->p, arb->contacts[j].r1);
 				cpVect p2 = cpvadd(arb->body_b->p, arb->contacts[j].r2);
-				
+
 				cpFloat d = 2.0f;
 				cpVect a = cpvadd(p1, cpvmult(n, -d));
-				cpVect b = cpvadd(p2, cpvmult(n,  d));
+				cpVect b = cpvadd(p2, cpvmult(n, d));
+
+				a = cpTransformPoint(options->transform, a);
+				b = cpTransformPoint(options->transform, b);
 				draw_seg(a, b, color, data);
 			}
 		}


### PR DESCRIPTION
This PR adds a transform property to cpSpaceDebugDrawOptions, and the transform is applied on the drawing of shapes. However, it is not applied to the size of the dot when drawing constraints. In this way you can make a scaling transform and zoom in without the constraint dots filling up the screen hiding everything else.

This is also the reason why this change has to be done in cpSpaceDebug, since if I just do the transform inside the draw functions (dot, segment, fat segment etc) drawing of DampedSpring will not work nicely. (This is what I tried first)

Code can most likely be optimized further, Im open to suggestions.