### PR TITLE
Fix compiling with TinyC (tcc) compiler (Fixes #210)

### DIFF
--- a/demo/ChipmunkDebugDraw.c
+++ b/demo/ChipmunkDebugDraw.c
@@ -273,7 +273,7 @@ void ChipmunkDebugDrawPolygon(int count, const cpVect *verts, cpFloat radius, cp
 
 void ChipmunkDebugDrawBB(cpBB bb, cpSpaceDebugColor color)
 {
-	cpVect verts[] = {
+	cpVect verts[4] = {
 		cpv(bb.r, bb.b),
 		cpv(bb.r, bb.t),
 		cpv(bb.l, bb.t),

--- a/demo/Planet.c
+++ b/demo/Planet.c
@@ -62,7 +62,7 @@ add_box(cpSpace *space)
 	const cpFloat size = 10.0f;
 	const cpFloat mass = 1.0f;
 	
-	cpVect verts[] = {
+	cpVect verts[4] = {
 		cpv(-size,-size),
 		cpv(-size, size),
 		cpv( size, size),

--- a/demo/Plink.c
+++ b/demo/Plink.c
@@ -72,7 +72,7 @@ init(void)
 	cpShape *shape;
 	
 	// Vertexes for a triangle shape.
-	cpVect tris[] = {
+	cpVect tris[4] = {
 		cpv(-15,-15),
 		cpv(  0, 10),
 		cpv( 15,-15),

--- a/demo/Pump.c
+++ b/demo/Pump.c
@@ -109,7 +109,7 @@ init(void)
 	cpShapeSetFriction(shape, 0.5f);
 	cpShapeSetFilter(shape, NOT_GRABBABLE_FILTER);
 
-	cpVect verts[] = {
+	cpVect verts[4] = {
 		cpv(-30,-80),
 		cpv(-30, 80),
 		cpv( 30, 64),

--- a/src/cpPolyShape.c
+++ b/src/cpPolyShape.c
@@ -234,7 +234,7 @@ cpBoxShapeInit(cpPolyShape *poly, cpBody *body, cpFloat width, cpFloat height, c
 cpPolyShape *
 cpBoxShapeInit2(cpPolyShape *poly, cpBody *body, cpBB box, cpFloat radius)
 {
-	cpVect verts[] = {
+	cpVect verts[4] = {
 		cpv(box.r, box.b),
 		cpv(box.r, box.t),
 		cpv(box.l, box.t),


### PR DESCRIPTION
This PR enables Chipmunk to be compiled with `tcc`. Closes #210 