### PR TITLE
Fix cast between incompatible function type

### DIFF
--- a/src/cpBBTree.c
+++ b/src/cpBBTree.c
@@ -544,7 +544,7 @@ cpBBTreeAlloc(void)
 	return (cpBBTree *)cpcalloc(1, sizeof(cpBBTree));
 }
 
-static int
+static cpBool
 leafSetEql(void *obj, Node *node)
 {
 	return (obj == node->obj);

--- a/src/cpSpaceHash.c
+++ b/src/cpSpaceHash.c
@@ -69,7 +69,7 @@ cpHandleRelease(cpHandle *hand, cpArray *pooledHandles)
 	if(hand->retain == 0) cpArrayPush(pooledHandles, hand);
 }
 
-static int handleSetEql(void *obj, cpHandle *hand){return (obj == hand->obj);}
+static cpBool handleSetEql(void *obj, cpHandle *hand){return (obj == hand->obj);}
 
 static void *
 handleSetTrans(void *obj, cpSpaceHash *hash)
@@ -564,7 +564,7 @@ cpSpaceHashCount(cpSpaceHash *hash)
 	return cpHashSetCount(hash->handleSet);
 }
 
-static int
+static cpBool
 cpSpaceHashContains(cpSpaceHash *hash, void *obj, cpHashValue hashid)
 {
 	return cpHashSetFind(hash->handleSet, hashid, obj) != NULL;

--- a/src/cpSweep1D.c
+++ b/src/cpSweep1D.c
@@ -117,7 +117,7 @@ cpSweep1DEach(cpSweep1D *sweep, cpSpatialIndexIteratorFunc func, void *data)
 	for(int i=0, count=sweep->num; i<count; i++) func(table[i].obj, data);
 }
 
-static int
+static cpBool 
 cpSweep1DContains(cpSweep1D *sweep, void *obj, cpHashValue hashid)
 {
 	TableCell *table = sweep->table;


### PR DESCRIPTION
These 4 functions should return cpBool.

Fixes these warnings:

[23/32] Building C object CMakeFiles/lib/Chipmunk2D/src/cpSweep1D.c.o                                          
../../lib/Chipmunk2D/src/cpSweep1D.c:251:2: warning: cast between incompatible function types from ‘int (*)(cpSweep1D *, void *, cpHashValue)’ {aka ‘int (*)(cpSweep1D *, void *, long unsigned int)’} to ‘cpBool (*)(cpSpatialIndex *, void *
, cpHashValue)’ {aka ‘unsigned char (*)(cpSpatialIndex *, void *, long unsigned int)’} [-Wcast-function-type]                                                                                                                                   251 |  (cpSpatialIndexContainsImpl)cpSweep1DContains,                                                                
      |  ^                                                                                                             
[26/32] Building C object CMakeFiles/lib/Chipmunk2D/src/cpBBTree.c.o                                           
../../lib/Chipmunk2D/src/cpBBTree.c: In function ‘cpBBTreeInit’:                                                                                                                                                                              
../../lib/Chipmunk2D/src/cpBBTree.c:573:33: warning: cast between incompatible function types from ‘int (*)(void *, Node *)’ to ‘cpBool (*)(const void *, const void *)’ {aka ‘unsigned char (*)(const void *, const void *)’} [-Wcast-functio
n-type]                                                                                                                
  573 |  tree->leaves = cpHashSetNew(0, (cpHashSetEqlFunc)leafSetEql);                                                 
      |                                 ^                                                                                                                                                                                                     
[29/32] Building C object CMakeFiles/lib/Chipmunk2D/src/cpSpaceHash.c.o                                        
../../lib/Chipmunk2D/src/cpSpaceHash.c: In function ‘cpSpaceHashInit’:                                                 
../../lib/Chipmunk2D/src/cpSpaceHash.c:181:36: warning: cast between incompatible function types from ‘int (*)(void *, cpHandle *)’ to ‘cpBool (*)(const void *, const void *)’ {aka ‘unsigned char (*)(const void *, const void *)’} [-Wcast-
function-type]                                                                                                                                                                                                                                
  181 |  hash->handleSet = cpHashSetNew(0, (cpHashSetEqlFunc)handleSetEql);                                                                                                                                                                   
      |                                    ^                                                                           
../../lib/Chipmunk2D/src/cpSpaceHash.c: At top level:                                                                  
../../lib/Chipmunk2D/src/cpSpaceHash.c:578:2: warning: cast between incompatible function types from ‘int (*)(cpSpaceHash *, void *, cpHashValue)’ {aka ‘int (*)(cpSpaceHash *, void *, long unsigned int)’} to ‘cpBool (*)(cpSpatialIndex *, 
void *, cpHashValue)’ {aka ‘unsigned char (*)(cpSpatialIndex *, void *, long unsigned int)’} [-Wcast-function-type]                                                                                                                           
  578 |  (cpSpatialIndexContainsImpl)cpSpaceHashContains,                                                              
      |  