### PR TITLE
Add cpShapeIsPoly, cpShapeIsSegment, cpShapeIsCircle functions

### DIFF
--- a/include/chipmunk/cpPolyShape.h
+++ b/include/chipmunk/cpPolyShape.h
@@ -53,4 +53,7 @@ CP_EXPORT cpVect cpPolyShapeGetVert(const cpShape *shape, int index);
 /// Get the radius of a polygon shape.
 CP_EXPORT cpFloat cpPolyShapeGetRadius(const cpShape *shape);
 
+/// Query if shape is a polygon shape.
+CP_EXPORT cpBool cpShapeIsPoly(const cpShape *shape);
+
 /// @}

--- a/include/chipmunk/cpShape.h
+++ b/include/chipmunk/cpShape.h
@@ -174,6 +174,9 @@ CP_EXPORT cpVect cpCircleShapeGetOffset(const cpShape *shape);
 /// Get the radius of a circle shape.
 CP_EXPORT cpFloat cpCircleShapeGetRadius(const cpShape *shape);
 
+/// Query if shape is a polygon shape.
+CP_EXPORT cpBool cpShapeIsCircle(const cpShape *shape);
+
 /// @}
 /// @defgroup cpSegmentShape cpSegmentShape
 
@@ -195,5 +198,8 @@ CP_EXPORT cpVect cpSegmentShapeGetB(const cpShape *shape);
 CP_EXPORT cpVect cpSegmentShapeGetNormal(const cpShape *shape);
 /// Get the first endpoint of a segment shape.
 CP_EXPORT cpFloat cpSegmentShapeGetRadius(const cpShape *shape);
+
+/// Query if shape is a segment shape.
+CP_EXPORT cpBool cpShapeIsSegment(const cpShape *shape);
 
 /// @}

--- a/src/cpPolyShape.c
+++ b/src/cpPolyShape.c
@@ -322,3 +322,9 @@ cpPolyShapeSetRadius(cpShape *shape, cpFloat radius)
 //	shape->massInfo = cpPolyShapeMassInfo(shape->massInfo.m, poly->count, poly->verts, poly->r);
 //	if(mass > 0.0f) cpBodyAccumulateMassFromShapes(shape->body);
 }
+
+cpBool
+cpShapeIsPoly(const cpShape *shape)
+{
+	return shape->klass == &polyClass;
+}

--- a/src/cpShape.c
+++ b/src/cpShape.c
@@ -368,6 +368,11 @@ cpCircleShapeGetRadius(const cpShape *shape)
 	return ((cpCircleShape *)shape)->r;
 }
 
+cpBool
+cpShapeIsCircle(const cpShape *shape)
+{
+	return shape->klass == &cpCircleShapeClass;
+}
 
 cpSegmentShape *
 cpSegmentShapeAlloc(void)
@@ -601,4 +606,10 @@ cpSegmentShapeSetRadius(cpShape *shape, cpFloat radius)
 	cpFloat mass = shape->massInfo.m;
 	shape->massInfo = cpSegmentShapeMassInfo(shape->massInfo.m, seg->a, seg->b, seg->r);
 	if(mass > 0.0f) cpBodyAccumulateMassFromShapes(shape->body);
+}
+
+cpBool
+cpShapeIsSegment(const cpShape *shape)
+{
+	return shape->klass == &cpSegmentShapeClass;
 }


### PR DESCRIPTION
Addresses #219.

Imagine you are writing a cpShapeEach callback to draw a scene which contains both circle and poly shapes. At the moment, there is no way to determine whether any one shape addressed by the callback is a circle, a poly, or something else. However telling circles and polys apart is necessary because functions like cpPolyShapeGetCount() assert-crash when called on the wrong kind of shape.

This patch adds three new functions `cpShapeIsPoly`, `cpShapeIsSegment`, `cpShapeIsCircle` that do the expected thing. I am indifferent to whether this is the best naming for these functions.

I tested this by doing a successful build and calling cpShapeIsPoly in live code (although my tests were in a feature branch based on older Chipmunk.) I did not attempt to modify any documentation.