### PR TITLE
Fix MSVC dll import/export

### DIFF
--- a/include/chipmunk/chipmunk.h
+++ b/include/chipmunk/chipmunk.h
@@ -38,8 +38,8 @@
 #ifdef _WIN32
 	#ifdef CHIPMUNK_SHARED
 		#ifdef CHIPMUNK_BUILD
-	#define CP_EXPORT __declspec(dllexport)
-#else
+			#define CP_EXPORT __declspec(dllexport)
+		#else
 			#define CP_EXPORT __declspec(dllimport)
 		#endif
 	#else
@@ -119,7 +119,10 @@ typedef struct cpArbiter cpArbiter;
 typedef struct cpSpace cpSpace;
 
 #include "cpVect.h"
+#include "cpRobust.h"
+#include "cpHastySpace.h"
 #include "cpBB.h"
+#include "cpMarch.h"
 #include "cpTransform.h"
 #include "cpSpatialIndex.h"
 

--- a/include/chipmunk/chipmunk.h
+++ b/include/chipmunk/chipmunk.h
@@ -36,7 +36,15 @@
 #endif
 
 #ifdef _WIN32
+	#ifdef CHIPMUNK_SHARED
+		#ifdef CHIPMUNK_BUILD
 	#define CP_EXPORT __declspec(dllexport)
+#else
+			#define CP_EXPORT __declspec(dllimport)
+		#endif
+	#else
+		#define CP_EXPORT
+	#endif
 #else
 	#define CP_EXPORT
 #endif

--- a/include/chipmunk/cpRobust.h
+++ b/include/chipmunk/cpRobust.h
@@ -5,7 +5,7 @@
 // "Fast math" should be disabled here.
 
 // Check if c is to the left of segment (a, b).
-cpBool cpCheckPointGreater(const cpVect a, const cpVect b, const cpVect c);
+CP_EXPORT cpBool cpCheckPointGreater(const cpVect a, const cpVect b, const cpVect c);
 
 // Check if p is behind one of v0 or v1 on axis n.
-cpBool cpCheckAxis(cpVect v0, cpVect v1, cpVect p, cpVect n);
+CP_EXPORT cpBool cpCheckAxis(cpVect v0, cpVect v1, cpVect p, cpVect n);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,6 +19,8 @@ if(BUILD_SHARED)
   if(MSVC)
     set_source_files_properties(${chipmunk_source_files} PROPERTIES LANGUAGE CXX)
     set_target_properties(chipmunk PROPERTIES LINKER_LANGUAGE CXX)
+    target_compile_options(chipmunk PRIVATE CHIPMUNK_BUILD
+                                    PUBLIC CHIPMUNK_SHARED)
   endif(MSVC)
   # set the lib's version number
   # But avoid on Android because symlinks to version numbered .so's don't work with Android's Java-side loadLibrary.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,7 +19,7 @@ if(BUILD_SHARED)
   if(MSVC)
     set_source_files_properties(${chipmunk_source_files} PROPERTIES LANGUAGE CXX)
     set_target_properties(chipmunk PROPERTIES LINKER_LANGUAGE CXX)
-    target_compile_options(chipmunk PRIVATE CHIPMUNK_BUILD
+    target_compile_definitions(chipmunk PRIVATE CHIPMUNK_BUILD
                                     PUBLIC CHIPMUNK_SHARED)
   endif(MSVC)
   # set the lib's version number

--- a/src/cpRobust.c
+++ b/src/cpRobust.c
@@ -1,4 +1,4 @@
-#include "chipmunk/cpRobust.h"
+#include "chipmunk/chipmunk_private.h"
 
 
 cpBool


### PR DESCRIPTION
Problem: When building a dll on Windows with MSVC some symbols are not exported while others are exported with C++ name mangling rather than C.

Solution: Add CP_EXPORT to functions not exported. Add define block to handle __declspec(dllexport) and __declspec(dllimport.). Note: this solution requires a new define added to instruct the compiler to look for a shared library or a static library. This only applies when _WIN32 is defined.

This may fix #194 and #116