### PR TITLE
Compile fixes for C on MSVC

### DIFF
--- a/include/chipmunk/cpMarch.h
+++ b/include/chipmunk/cpMarch.h
@@ -1,6 +1,10 @@
 // Copyright 2013 Howling Moon Software. All rights reserved.
 // See http://chipmunk2d.net/legal.php for more information.
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /// Function type used as a callback from the marching squares algorithm to sample an image function.
 /// It passes you the point to sample and your context pointer, and you return the density.
 typedef cpFloat (*cpMarchSampleFunc)(cpVect point, void *data);
@@ -26,3 +30,7 @@ CP_EXPORT void cpMarchHard(
   cpMarchSegmentFunc segment, void *segment_data,
   cpMarchSampleFunc sample, void *sample_data
 );
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/chipmunk/cpPolyline.h
+++ b/include/chipmunk/cpPolyline.h
@@ -1,6 +1,10 @@
 // Copyright 2013 Howling Moon Software. All rights reserved.
 // See http://chipmunk2d.net/legal.php for more information.
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // Polylines are just arrays of vertexes.
 // They are looped if the first vertex is equal to the last.
 // cpPolyline structs are intended to be passed by value and destroyed when you are done with them.
@@ -68,3 +72,7 @@ CP_EXPORT void cpPolylineSetCollectSegment(cpVect v0, cpVect v1, cpPolylineSet *
 CP_EXPORT cpPolylineSet *cpPolylineConvexDecomposition(cpPolyline *line, cpFloat tol);
 
 #define cpPolylineConvexDecomposition_BETA cpPolylineConvexDecomposition
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/cpBody.c
+++ b/src/cpBody.c
@@ -103,9 +103,9 @@ cpBodyFree(cpBody *body)
 #ifdef NDEBUG
 	#define	cpAssertSaneBody(body)
 #else
-	static void cpv_assert_nan(cpVect v, char *message){cpAssertHard(v.x == v.x && v.y == v.y, message);}
-	static void cpv_assert_infinite(cpVect v, char *message){cpAssertHard(cpfabs(v.x) != INFINITY && cpfabs(v.y) != INFINITY, message);}
-	static void cpv_assert_sane(cpVect v, char *message){cpv_assert_nan(v, message); cpv_assert_infinite(v, message);}
+	static void cpv_assert_nan(cpVect v, const char *message){cpAssertHard(v.x == v.x && v.y == v.y, message);}
+	static void cpv_assert_infinite(cpVect v, const char *message){cpAssertHard(cpfabs(v.x) != INFINITY && cpfabs(v.y) != INFINITY, message);}
+	static void cpv_assert_sane(cpVect v, const char *message){cpv_assert_nan(v, message); cpv_assert_infinite(v, message);}
 	
 	static void
 	cpBodySanityCheck(const cpBody *body)


### PR DESCRIPTION
Fixes compilation with MSVC when using Chipmunk2D from C compiled as C

1. Use const char* to avoid a warning
2. Add extern "C" to fix linker errors in a couple files which need to be included directly (Chipmunk2D's CMakeLists.txt instructs MSVC to compile the corresponding C files as C++ hence the symbols are missing at link time)