### PR TITLE
Fixed broken planetmath.org url

### DIFF
--- a/src/prime.h
+++ b/src/prime.h
@@ -21,7 +21,7 @@
 
 // Used for resizing hash tables.
 // Values approximately double.
-// http://planetmath.org/encyclopedia/GoodHashTablePrimes.html
+// https://planetmath.org/goodhashtableprimes
 static int primes[] = {
 	5,
 	13,


### PR DESCRIPTION
I happened to notice that [this](https://github.com/slembcke/Chipmunk2D/blob/d0239ef4599b3688a5a336373f7d0a68426414ba/src/prime.h#L24) URL to planetmath.org happened to be broken. I'm sure I'm the only one to have tried this in the last decade and will probably be the last one to try for the next decade, but maybe it is still worth fixing. I updated it from http://planetmath.org/encyclopedia/GoodHashTablePrimes.html to the functional https://planetmath.org/goodhashtableprimes