### PR TITLE
Fix impulse of cpDampedRotarySpring #248

### DIFF
--- a/src/cpDampedRotarySpring.c
+++ b/src/cpDampedRotarySpring.c
@@ -65,7 +65,7 @@ applyImpulse(cpDampedRotarySpring *spring, cpFloat dt)
 	
 	//apply_impulses(a, b, spring->r1, spring->r2, cpvmult(spring->n, v_damp*spring->nMass));
 	cpFloat j_damp = w_damp*spring->iSum;
-	spring->jAcc += j_damp;
+	spring->jAcc -= j_damp;
 	
 	a->w += j_damp*a->i_inv;
 	b->w -= j_damp*b->i_inv;


### PR DESCRIPTION
Fixes the calculation of impulse for the cpDampedRotarySpring, which before this fix used the wrong sign to add the "damping" impulse to the total impulse.