### PR TITLE
Missing __declspec(dllimport) in chipmunk.h

### DIFF
--- a/include/chipmunk/chipmunk.h
+++ b/include/chipmunk/chipmunk.h
@@ -36,7 +36,11 @@
 #endif
 
 #ifdef _WIN32
-	#define CP_EXPORT __declspec(dllexport)
+        #ifdef chipmunk_EXPORTS
+            #define CP_EXPORT __declspec(dllexport)
+        #else
+            #define CP_EXPORT __declspec(dllimport)
+        #endif
 #else
 	#define CP_EXPORT
 #endif


### PR DESCRIPTION
`__declspec(dllimport)` is missing in `chipmunk.h` when defining `CP_EXPORT`