### PR TITLE
Minor cmake maintenance

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.7)
+cmake_minimum_required(VERSION 3.7...4.0)
 
 project(chipmunk)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,11 +14,23 @@ if(NOT CMAKE_BUILD_TYPE)
       FORCE)
 endif()
 
+include(GNUInstallDirs)
 # to manually select install locations of libraries and executables
 #   -D LIB_INSTALL_DIR mylib
 #   -D BIN_INSTALL_DIR newbin
-set(LIB_INSTALL_DIR lib CACHE STRING "Install location of libraries")
-set(BIN_INSTALL_DIR bin CACHE STRING "Install location of executables")
+if(DEFINED LIB_INSTALL_DIR)
+  message(WARNING
+      "LIB_INSTALL_DIR is deprecated, use the standard CMAKE_INSTALL_LIBDIR instead."
+  )
+else()
+  set(LIB_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}")
+endif()
+if(DEFINED BIN_INSTALL_DIR)
+  message(WARNING
+      "LIB_INSTALL_DIR is deprecated, use the standard CMAKE_INSTALL_LIBDIR instead."
+  )
+  set(LIB_INSTALL_DIR "${CMAKE_INSTALL_BINDIR}")
+endif()
 
 # other options for the build, you can i.e. activate the shared library by passing
 #   -D BUILD_SHARED=ON

--- a/demo/CMakeLists.txt
+++ b/demo/CMakeLists.txt
@@ -42,5 +42,5 @@ add_executable(chipmunk_demos ${chipmunk_demos_source_files})
 target_link_libraries(chipmunk_demos ${chipmunk_demos_libraries})
 
 if(INSTALL_DEMOS)
-	install(TARGETS chipmunk_demos RUNTIME DESTINATION bin)
+	install(TARGETS chipmunk_demos)
 endif(INSTALL_DEMOS)

--- a/demo/CMakeLists.txt
+++ b/demo/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_policy(SET CMP0015 NEW) # Convert relative paths
-
 set(OpenGL_GL_PREFERENCE GLVND)
 find_package(OpenGL REQUIRED)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -53,7 +53,7 @@ if(BUILD_STATIC)
 endif(BUILD_STATIC)
 
 if(BUILD_SHARED OR INSTALL_STATIC)
-  # FIXME: change to PUBLIC_HEADER to allow building frameworks
-  install(FILES ${chipmunk_public_header} DESTINATION include/chipmunk)
-  install(FILES ${chipmunk_constraint_header} DESTINATION include/chipmunk/constraints)
+  # FIXME: change to target_sources(FILE_SET)
+  install(FILES ${chipmunk_public_header} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/chipmunk)
+  install(FILES ${chipmunk_constraint_header} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/chipmunk/constraints)
 endif(BUILD_SHARED OR INSTALL_STATIC)


### PR DESCRIPTION
- Use higher-bound policies (reduces downstream maintenance)
- Use standard `GNUInstallDirs` defaults